### PR TITLE
feat (rules): no describe duplicates

### DIFF
--- a/lib/rules/no-describe-dups.js
+++ b/lib/rules/no-describe-dups.js
@@ -1,0 +1,32 @@
+'use strict';
+
+/**
+ * @fileoverview Disallow the use of duplicate suite names
+ * @author Alexander Afanasyev
+ */
+
+var linter = require("eslint").linter;
+
+module.exports = function (context) {
+  var check = function (node) {
+
+    if (node.callee.name === "describe" && node.arguments) {
+      var name = node.arguments[0].value;
+
+      if (!linter.describeNames) {
+        linter.describeNames = [name];
+      } else {
+        if (linter.describeNames.indexOf(name) !== -1) {
+          context.report(node, "Duplicate describe name: '{{name}}'", {
+            name: name
+          });
+        }
+        linter.describeNames.push(name);
+      }
+    }
+  };
+
+  return {
+    "CallExpression": check
+  }
+};

--- a/test/rules/no-describe-dups.js
+++ b/test/rules/no-describe-dups.js
@@ -1,0 +1,23 @@
+'use strict';
+
+var linter = require('eslint').linter;
+var ESLintTester = require('eslint-tester');
+
+var eslintTester = new ESLintTester(linter);
+eslintTester.addRuleTest('lib/rules/no-describe-dups', {
+  valid: [
+    'describe("The first describe name", function() {}); ' +
+    'describe("The second describe name", function() {})'
+  ],
+
+  invalid: [
+    {
+      code: 'describe("Same describe name", function() {}); ' +
+            'describe("Same describe name", function() {})',
+      errors: [{
+        message: "Duplicate describe name: 'Same describe name'",
+        type: 'CallExpression'
+      }]
+    }
+  ]
+});


### PR DESCRIPTION
This should close issue #3.

I was thinking about where to keep the describe names across the lint calls, decided to use `linter` object for it. Hope this is the correct way of doing it. Please confirm.