### PR TITLE
Add the "branch" option to `no-suite-dupes` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@
 
 This plugin ships with a default configuration for each rule:
 
-Rule                    | Default
-----                    | -------
-[no-focused-tests][]    | 2
-[no-disabled-tests][]   | 1
-[no-suite-dupes][]      | 1
+Rule                    | Default    | Options
+----                    | -------    | -------
+[no-focused-tests][]    | 2          |
+[no-disabled-tests][]   | 1          |
+[no-suite-dupes][]      | 1, 'block' | ['block', 'branch']
 
 For example, the `no-focused-tests` rule is enabled by default and will cause
 ESLint to throw an error (with an exit code of `1`) when triggered.
@@ -43,6 +43,9 @@ plugins:
   - jasmine
 rules:
   jasmine/no-focused-tests: 0
+  jasmine/no-suite-dupes:
+    - 2
+    - "branch"
 ```
 
 See [configuring rules][] for more information.

--- a/docs/rules/no-suite-dupes.md
+++ b/docs/rules/no-suite-dupes.md
@@ -10,6 +10,8 @@ copy-paste error.
 This rule triggers a **warning** (is set to **1** by default) whenever it
 encounters duplicated suite names.
 
+### Block mode (default)
+
 The following patterns are considered warnings:
 
 ```js
@@ -17,9 +19,51 @@ describe("Same suite name", function() {});
 describe("Same suite name", function() {});
 ```
 
+```js
+describe("Unique parent", function(){
+  // ...
+});
+describe("Different parent", function(){
+  // ...
+});
+```
+
 The following patterns are not warnings:
 
 ```js
 describe("The first suite name", function() {});
 describe("The second suite name", function() {});
+```
+
+### Branch mode
+
+In this mode, `describe` can share the same description unless the branch they
+form has already be defined.
+
+The following patterns are considered warnings:
+
+```js
+describe("Parent context", function(){
+  describe("Same branch", function(){
+    // ...
+  });
+  describe("Same branch", function(){
+    // ...
+  });
+});
+```
+
+The following patterns are not warnings:
+
+```js
+describe("Some context", function(){
+  describe("Same branch", function(){
+    // ...
+  });
+});
+describe("Another context", function(){
+  describe("Same branch", function(){
+    // ...
+  });
+});
 ```

--- a/lib/rules/no-suite-dupes.js
+++ b/lib/rules/no-suite-dupes.js
@@ -4,16 +4,32 @@
  * @fileoverview Disallow the use of duplicate suite names
  * @author Alexander Afanasyev
  */
-var suites = [];
-
 module.exports = function(context) {
+
+
+  var suites = [];
+  var branch = [];
+  var branchMode = context.options[0] === 'branch';
+
+  function notJasmine(node) {
+    return node.callee.name !== 'describe' || !node.arguments;
+  }
+
   return {
     'CallExpression': function(node) {
-      if (node.callee.name !== 'describe' || !node.arguments) {
+      if (notJasmine(node)) {
         return;
       }
 
-      var suite = node.arguments[0].value;
+      var block = node.arguments[0].value;
+      var suite;
+
+      if (branchMode) {
+        branch.push(block);
+        suite = branch.join(' ');
+      } else {
+        suite = block;
+      }
 
       if (suites.indexOf(suite) !== -1) {
         context.report(node, 'Duplicate suite: "{{suite}}"', {
@@ -22,6 +38,24 @@ module.exports = function(context) {
       }
 
       suites.push(suite);
+    },
+    'CallExpression:exit': function(node) {
+      if (notJasmine(node)) {
+        return;
+      }
+
+      if (branchMode) {
+        branch.pop();
+      }
     }
   };
 };
+
+module.exports.schema = [
+  {
+    enum: [
+      'block',
+      'branch'
+    ]
+  }
+];

--- a/test/rules/no-suite-dupes.js
+++ b/test/rules/no-suite-dupes.js
@@ -5,19 +5,214 @@ var ESLintTester = require('eslint-tester');
 
 var eslintTester = new ESLintTester(linter);
 
+/*
+ * Generate readble code lines block
+ * // description
+ * lines[0]
+ * lines[1]
+ * ...
+ * lines[n]
+ */
+function toCode(lines, description) {
+  return (description ? '// ' + description : '') + '\n' + lines.join('\n');
+}
+
 eslintTester.addRuleTest('lib/rules/no-suite-dupes', {
   valid: [
-    'describe("The first suite name", function() {}); ' +
-    'describe("The second suite name", function() {})'
-  ],
+    // default
+    toCode([
+      'describe("The first suite name", function() {}); ',
+      'describe("The second suite name", function() {})'
+    ]),
+    {
+      code: toCode([
+        'describe("Some context", function() {',
+        '  // it(...',
+        '});',
+        'describe("Different context", function() {',
+        '  // it(...',
+        '});'
+      ], 'same it in different context')
+    },
 
+    // 'block'
+    {
+      args: [
+        2,
+        'block'
+      ],
+      code: toCode([
+        'describe("The first suite name", function() {}); ',
+        'describe("The second suite name", function() {})'
+      ])
+    },
+
+    // 'branch'
+    {
+      args: [
+        2,
+        'branch'
+      ],
+      code: toCode([
+        'describe("The first suite name", function() {}); ',
+        'describe("The second suite name", function() {})'
+      ])
+    },
+    {
+      args: [
+        2,
+        'branch'
+      ],
+      code: toCode([
+        'describe("unique", function(){',
+        '  // it(...',
+        '});',
+        'describe("different", function(){',
+        '  // it(...',
+        '});'
+      ], 'same block in different parent blocks')
+    },
+    {
+      args: [
+        2,
+        'branch'
+      ],
+      code: toCode([
+        'describe("context", function(){',
+        '  describe("unique", function(){',
+        '    // it(...',
+        '  });',
+        '  describe("different", function(){',
+        '    // it(...',
+        '  });',
+        '});'
+      ], 'difference in middle-nest block')
+    },
+    {
+      args: [
+        2,
+        'branch'
+      ],
+      code: toCode([
+        'describe("same", function(){',
+        '  describe("same", function(){',
+        '    // it(...',
+        '  });',
+        '});'
+      ])
+    }
+  ],
   invalid: [
     {
-      code: 'describe("Same suite name", function() {}); ' +
-            'describe("Same suite name", function() {})',
+      // default
+      code: toCode([
+        'describe("Same suite name", function() {});',
+        'describe("Same suite name", function() {})'
+      ]),
       errors: [
         {
           message: 'Duplicate suite: "Same suite name"',
+          type: 'CallExpression'
+        }
+      ]
+    },
+
+    // 'block'
+    {
+      args: [
+        2,
+        'block'
+      ],
+      code: toCode([
+        'describe("Same suite name", function() {}); ',
+        'describe("Same suite name", function() {})'
+      ]),
+      errors: [
+        {
+          message: 'Duplicate suite: "Same suite name"',
+          type: 'CallExpression'
+        }
+      ]
+    },
+    {
+      args: [
+        2,
+        'block'
+      ],
+      code: toCode([
+        'describe("Parent context", function(){',
+        '  describe("Same block", function(){',
+        '    describe("Same block", function(){',
+        '      // it(...',
+        '    });',
+        '  });',
+        '});'
+      ], 'same block withing the same branch'),
+      errors: [
+        {
+          message: 'Duplicate suite: "Same block"',
+          type: 'CallExpression'
+        }
+      ]
+    },
+
+    // 'branch'
+    {
+      args: [
+        2,
+        'branch'
+      ],
+      code: toCode([
+        'describe("Same suite name", function() {}); ',
+        'describe("Same suite name", function() {})'
+      ], 'same blocks'),
+      errors: [
+        {
+          message: 'Duplicate suite: "Same suite name"',
+          type: 'CallExpression'
+        }
+      ]
+    },
+    {
+      args: [
+        2,
+        'branch'
+      ],
+      code: toCode([
+        'describe("parent context", function(){',
+        '  describe("same", function(){',
+        '    // it(...',
+        '  });',
+        '  describe("same", function(){',
+        '    // it(...',
+        '  });',
+        '});'
+      ], 'same block in different contexts'),
+      errors: [
+        {
+          message: 'Duplicate suite: "parent context same"',
+          type: 'CallExpression'
+        }
+      ]
+    },
+    {
+      args: [
+        2,
+        'branch'
+      ],
+      code: toCode([
+        'describe("parent context", function(){',
+        '  describe("same", function(){',
+        '    // it(...',
+        '  });',
+        '  describe("same", function(){',
+        '    // it(...',
+        '  });',
+        '});'
+      ], 'same block in the middle of branches'),
+      errors: [
+        {
+          message: 'Duplicate suite: "parent context same"',
           type: 'CallExpression'
         }
       ]


### PR DESCRIPTION
This allows to have different `describe` block having the same name as long as they are nested differently

The default remains the block mode.

Comes with full documentation and tests

Fixes #6