### PR TITLE
feat(no-spec-dupes): Add `no-spec-dupes` rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Rule                    | Default    | Options
 ----                    | -------    | -------
 [no-focused-tests][]    | 2          |
 [no-disabled-tests][]   | 1          |
+[no-spec-dupes][]       | 1, 'block' | ['block', 'branch']
 [no-suite-dupes][]      | 1, 'block' | ['block', 'branch']
 
 For example, the `no-focused-tests` rule is enabled by default and will cause
@@ -52,6 +53,7 @@ See [configuring rules][] for more information.
 
 [no-focused-tests]: docs/rules/no-focused-tests.md
 [no-disabled-tests]: docs/rules/no-disabled-tests.md
+[no-spec-dupes]: docs/rules/no-spec-dupes.md
 [no-suite-dupes]: docs/rules/no-suite-dupes.md
 [configuring rules]: http://eslint.org/docs/user-guide/configuring#configuring-rules
 

--- a/docs/rules/no-spec-dupes.md
+++ b/docs/rules/no-spec-dupes.md
@@ -1,0 +1,78 @@
+# Disallow the use of duplicate spec names (no-spec-dupes)
+
+Jasmine uses `it` to begin and name a test spec.
+
+Multiple specs with the same name is confusing and is an indicator of a
+copy-paste error.
+
+## Rule details
+
+This rule triggers a **warning** (is set to **1** by default) whenever it
+encounters duplicated spec names.
+
+### Block mode (default)
+
+The following patterns are considered warnings:
+
+```js
+it("Same spec name", function() {});
+it("Same spec name", function() {});
+```
+
+```js
+describe("Unique parent", function(){
+  it("Same spec name", function() {});
+});
+describe("Different parent", function(){
+  it("Same spec name", function() {});
+});
+```
+
+The following patterns are not warnings:
+
+```js
+it("Different spec name", function() {});
+it("Unique spec name", function() {});
+```
+
+### Branch mode
+
+In this mode, `it` can share the same description unless the branch they
+form has already be defined.
+
+The following patterns are considered warnings:
+
+```js
+describe("Parent context", function(){
+  describe("Same branch", function(){
+    it("Same spec name", function() {});
+    it("Same spec name", function() {});
+  });
+});
+```
+
+```js
+describe("Parent context", function(){
+  describe("Same branch", function(){
+    it("Same spec name", function() {});
+  });
+  describe("Same branch", function(){
+    it("Same spec name", function() {});
+  });
+});
+```
+
+The following patterns are not warnings:
+
+```js
+describe("Some context", function(){
+  describe("Same branch", function(){
+    it("Same spec name", function() {});
+  });
+});
+describe("Another context", function(){
+  describe("Same branch", function(){
+    it("Same spec name", function() {});
+  });
+});
+```

--- a/docs/rules/no-suite-dupes.md
+++ b/docs/rules/no-suite-dupes.md
@@ -21,10 +21,10 @@ describe("Same suite name", function() {});
 
 ```js
 describe("Unique parent", function(){
-  // ...
+  describe("Same suite name", function() {});
 });
 describe("Different parent", function(){
-  // ...
+  describe("Same suite name", function() {});
 });
 ```
 

--- a/index.js
+++ b/index.js
@@ -4,11 +4,13 @@ module.exports = {
   rules: {
     'no-focused-tests': require('./lib/rules/no-focused-tests'),
     'no-disabled-tests': require('./lib/rules/no-disabled-tests'),
-    'no-suite-dupes': require('./lib/rules/no-suite-dupes')
+    'no-suite-dupes': require('./lib/rules/no-suite-dupes'),
+    'no-spec-dupes': require('./lib/rules/no-spec-dupes')
   },
   rulesConfig: {
     'no-focused-tests': 2,
     'no-disabled-tests': 1,
-    'no-suite-dupes': 1
+    'no-suite-dupes': 1,
+    'no-spec-dupes': 1
   }
 };

--- a/lib/no-dupes.js
+++ b/lib/no-dupes.js
@@ -1,0 +1,96 @@
+'use strict';
+
+/**
+ * @fileoverview Returns a rule that check for duplicated blocks
+ * @author Alexander Afanasyev
+ */
+module.exports = function(kind, branchBlocks, checkedBlocks){
+  function noDupes(context) {
+
+    var suites = [];
+    var branch = [];
+    var branchMode = context.options[0] === 'branch';
+
+    function isBranchNode(node) {
+      return branchBlocks.indexOf(node.callee.name) >= 0 || !node.arguments;
+    }
+
+    function isCheckedNode(node) {
+      return checkedBlocks.indexOf(node.callee.name) >= 0 || !node.arguments;
+    }
+
+    function extractLiteral(node) {
+      switch (node.type) {
+        case 'Literal':
+          return node.value;
+        case 'BinaryExpression':
+          if (node.operator === '+') {
+            return extractLiteral(node.left) + extractLiteral(node.right);
+          }
+          return null;
+        default:
+          return null;
+      }
+    }
+
+    return {
+      'CallExpression': function(node) {
+
+        if (!isBranchNode(node) && !isCheckedNode(node)) {
+          return;
+        }
+
+        var descriptionNode = node.arguments && node.arguments[0];
+
+        if (!descriptionNode) {
+          return;
+        }
+
+        var descriptionLiteral = extractLiteral(descriptionNode);
+
+        if (!descriptionLiteral) {
+          return;
+        }
+
+        if (branchMode) {
+          branch.push(descriptionLiteral);
+        }
+
+        if (isCheckedNode(node)) {
+
+          var suite;
+
+          if (branchMode) {
+            suite = branch.join(' ');
+          } else {
+            suite = descriptionLiteral;
+          }
+
+          if (suites.indexOf(suite) !== -1) {
+            context.report(node, 'Duplicate ' + kind + ': "{{suite}}"', {
+              suite: suite
+            });
+          }
+          suites.push(suite);
+        }
+      },
+      'CallExpression:exit': function(node) {
+
+        if (branchMode && (isBranchNode(node) || isCheckedNode(node))) {
+          branch.pop();
+        }
+      }
+    };
+  }
+
+  noDupes.schema = [
+    {
+      enum: [
+        'block',
+        'branch'
+      ]
+    }
+  ];
+
+  return noDupes;
+};

--- a/lib/rules/no-spec-dupes.js
+++ b/lib/rules/no-spec-dupes.js
@@ -1,0 +1,16 @@
+'use strict';
+
+/**
+ * @fileoverview Disallow the use of duplicate spec names
+ * @author Alexander Afanasyev
+ */
+
+var branchBlocks = [
+  'describe'
+];
+
+var checkedBlocks = [
+  'it'
+];
+
+module.exports = require('../no-dupes')('spec', branchBlocks, checkedBlocks);

--- a/lib/rules/no-suite-dupes.js
+++ b/lib/rules/no-suite-dupes.js
@@ -4,56 +4,13 @@
  * @fileoverview Disallow the use of duplicate suite names
  * @author Alexander Afanasyev
  */
-module.exports = function(context) {
-  var suites = [];
-  var branch = [];
-  var branchMode = context.options[0] === 'branch';
 
-  function notJasmine(node) {
-    return node.callee.name !== 'describe' || !node.arguments;
-  }
-
-  return {
-    'CallExpression': function(node) {
-      if (notJasmine(node)) {
-        return;
-      }
-
-      var block = node.arguments[0].value;
-      var suite;
-
-      if (branchMode) {
-        branch.push(block);
-        suite = branch.join(' ');
-      } else {
-        suite = block;
-      }
-
-      if (suites.indexOf(suite) !== -1) {
-        context.report(node, 'Duplicate suite: "{{suite}}"', {
-          suite: suite
-        });
-      }
-
-      suites.push(suite);
-    },
-    'CallExpression:exit': function(node) {
-      if (notJasmine(node)) {
-        return;
-      }
-
-      if (branchMode) {
-        branch.pop();
-      }
-    }
-  };
-};
-
-module.exports.schema = [
-  {
-    enum: [
-      'block',
-      'branch'
-    ]
-  }
+var branchBlocks = [
+  'describe'
 ];
+
+var checkedBlocks = [
+  'describe'
+];
+
+module.exports = require('../no-dupes')('suite', branchBlocks, checkedBlocks);

--- a/test/rules/no-spec-dupes.js
+++ b/test/rules/no-spec-dupes.js
@@ -17,12 +17,12 @@ function toCode(lines, description) {
   return (description ? '// ' + description : '') + '\n' + lines.join('\n');
 }
 
-eslintTester.addRuleTest('lib/rules/no-suite-dupes', {
+eslintTester.addRuleTest('lib/rules/no-spec-dupes', {
   valid: [
     // default
     toCode([
-      'describe("The first suite name", function() {}); ',
-      'describe("The second suite name", function() {})'
+      'it("The first spec name", function() {}); ',
+      'it("The second spec name", function() {})'
     ]),
     toCode([
       'unrelated("The first spec name", function() {}); ',
@@ -33,16 +33,16 @@ eslintTester.addRuleTest('lib/rules/no-suite-dupes', {
       'justAFunction();'
     ], 'a regular function'),
     toCode([
-      'describe("Handling" + " string " + "concatenation", function() {}); ',
-      'describe("Handling" + " it good", function() {})'
+      'it("Handling" + " string " + "concatenation", function() {}); ',
+      'it("Handling" + " it good", function() {})'
     ], 'description is concatenated string'),
     {
       code: toCode([
-        'describe("Some context", function() {',
-        '  // it(...',
+        'describe("context", function() {',
+        '  it("different", function(){});',
         '});',
-        'describe("Different context", function() {',
-        '  // it(...',
+        'describe("context", function() {',
+        '  it("unique", function(){});',
         '});'
       ], 'same it in different context')
     },
@@ -54,8 +54,8 @@ eslintTester.addRuleTest('lib/rules/no-suite-dupes', {
         'block'
       ],
       code: toCode([
-        'describe("The first suite name", function() {}); ',
-        'describe("The second suite name", function() {})'
+        'it("The first spec name", function() {}); ',
+        'it("The second spec name", function() {})'
       ])
     },
 
@@ -66,8 +66,8 @@ eslintTester.addRuleTest('lib/rules/no-suite-dupes', {
         'branch'
       ],
       code: toCode([
-        'describe("The first suite name", function() {}); ',
-        'describe("The second suite name", function() {})'
+        'describe("The first spec name", function() {}); ',
+        'describe("The second spec name", function() {})'
       ])
     },
     {
@@ -77,10 +77,10 @@ eslintTester.addRuleTest('lib/rules/no-suite-dupes', {
       ],
       code: toCode([
         'describe("unique", function(){',
-        '  // it(...',
+        '  it("spec", function(){});',
         '});',
         'describe("different", function(){',
-        '  // it(...',
+        '  it("spec", function(){});',
         '});'
       ], 'same block in different parent blocks')
     },
@@ -92,10 +92,10 @@ eslintTester.addRuleTest('lib/rules/no-suite-dupes', {
       code: toCode([
         'describe("context", function(){',
         '  describe("unique", function(){',
-        '    // it(...',
+        '    it("spec", function(){});',
         '  });',
         '  describe("different", function(){',
-        '    // it(...',
+        '    it("spec", function(){});',
         '  });',
         '});'
       ], 'difference in middle-nest block')
@@ -108,34 +108,50 @@ eslintTester.addRuleTest('lib/rules/no-suite-dupes', {
       code: toCode([
         'describe("same", function(){',
         '  describe("same", function(){',
-        '    // it(...',
+        '    it("spec", function(){});',
         '  });',
         '});'
       ])
+    },
+    {
+      args: [
+        2,
+        'branch'
+      ],
+      code: toCode([
+        'describe("same", function(){',
+        '  describe("same", function(){',
+        '    it("different", function(){});',
+        '  });',
+        '  describe("same", function(){',
+        '    it("unique", function(){});',
+        '  });',
+        '});'
+      ], 'same branch until spec')
     }
   ],
   invalid: [
     {
       // default
       code: toCode([
-        'describe("Same suite name", function() {});',
-        'describe("Same suite name", function() {})'
+        'it("Same spec name", function() {});',
+        'it("Same spec name", function() {})'
       ]),
       errors: [
         {
-          message: 'Duplicate suite: "Same suite name"',
+          message: 'Duplicate spec: "Same spec name"',
           type: 'CallExpression'
         }
       ]
     },
     {
       code: toCode([
-        'describe("Handling" + " string " + "concatenation", function() {}); ',
-        'describe("Handling string concatenation", function() {})'
+        'it("Handling" + " string " + "concatenation", function() {}); ',
+        'it("Handling string concatenation", function() {})'
       ], 'description is concatenated string'),
       errors: [
         {
-          message: 'Duplicate suite: "Handling string concatenation"',
+          message: 'Duplicate spec: "Handling string concatenation"',
           type: 'CallExpression'
         }
       ]
@@ -148,12 +164,12 @@ eslintTester.addRuleTest('lib/rules/no-suite-dupes', {
         'block'
       ],
       code: toCode([
-        'describe("Same suite name", function() {}); ',
-        'describe("Same suite name", function() {})'
+        'it("Same spec name", function() {}); ',
+        'it("Same spec name", function() {})'
       ]),
       errors: [
         {
-          message: 'Duplicate suite: "Same suite name"',
+          message: 'Duplicate spec: "Same spec name"',
           type: 'CallExpression'
         }
       ]
@@ -165,16 +181,17 @@ eslintTester.addRuleTest('lib/rules/no-suite-dupes', {
       ],
       code: toCode([
         'describe("Parent context", function(){',
-        '  describe("Same block", function(){',
-        '    describe("Same block", function(){',
-        '      // it(...',
-        '    });',
+        '  describe("Same parent", function(){',
+        '    it("Same spec", function(){});',
+        '  });',
+        '  describe("Same parent", function(){',
+        '    it("Same spec", function(){});',
         '  });',
         '});'
-      ], 'same block withing the same branch'),
+      ], 'same specs withing the same branch'),
       errors: [
         {
-          message: 'Duplicate suite: "Same block"',
+          message: 'Duplicate spec: "Same spec"',
           type: 'CallExpression'
         }
       ]
@@ -187,12 +204,12 @@ eslintTester.addRuleTest('lib/rules/no-suite-dupes', {
         'branch'
       ],
       code: toCode([
-        'describe("Same suite name", function() {}); ',
-        'describe("Same suite name", function() {})'
-      ], 'same blocks'),
+        'it("Spec name", function() {}); ',
+        'it("Spec name", function() {})'
+      ], 'same specs at root'),
       errors: [
         {
-          message: 'Duplicate suite: "Same suite name"',
+          message: 'Duplicate spec: "Spec name"',
           type: 'CallExpression'
         }
       ]
@@ -205,38 +222,16 @@ eslintTester.addRuleTest('lib/rules/no-suite-dupes', {
       code: toCode([
         'describe("parent context", function(){',
         '  describe("same", function(){',
-        '    // it(...',
+        '    it("spec", function(){});',
         '  });',
         '  describe("same", function(){',
-        '    // it(...',
+        '    it("spec", function(){});',
         '  });',
         '});'
-      ], 'same block in different contexts'),
+      ], 'same spec in different contexts'),
       errors: [
         {
-          message: 'Duplicate suite: "parent context same"',
-          type: 'CallExpression'
-        }
-      ]
-    },
-    {
-      args: [
-        2,
-        'branch'
-      ],
-      code: toCode([
-        'describe("parent context", function(){',
-        '  describe("same", function(){',
-        '    // it(...',
-        '  });',
-        '  describe("same", function(){',
-        '    // it(...',
-        '  });',
-        '});'
-      ], 'same block in the middle of branches'),
-      errors: [
-        {
-          message: 'Duplicate suite: "parent context same"',
+          message: 'Duplicate spec: "parent context same spec"',
           type: 'CallExpression'
         }
       ]


### PR DESCRIPTION
Moved 99% of the logic from `no-suites-dupes` out to `common/no-dupes`
There is no overlap between `no-suite-dupes` and `no-spec-dupes`: you
can check for `spec` dupes but not `suite` dupes and vice-versa (I
wonder who would do that though).

It comes with both `block (default)` and `branch` option. They worked
the same way they do for `no-suite-dupes`: in block mode, we check for
individual `it` block being duplicated while in `branch` mode we check
for the whole branc (i.e. chain of `describes` up to the `it` block) for
duplicated names.

It also now handle concatenaed description strings, such as:
`it('should ' + 'do stuff');`

Fixes #8