### PR TITLE
feat(missing-expect): add missing-expect rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,13 @@
 
 This plugin ships with a default configuration for each rule:
 
-Rule                    | Default    | Options
-----                    | -------    | -------
-[no-focused-tests][]    | 2          |
-[no-disabled-tests][]   | 1          |
-[no-spec-dupes][]       | 1, 'block' | ['block', 'branch']
-[no-suite-dupes][]      | 1, 'block' | ['block', 'branch']
+Rule                    | Default       | Options
+----                    | -------       | -------
+[no-focused-tests][]    | 2             |
+[no-disabled-tests][]   | 1             |
+[no-spec-dupes][]       | 1, 'block'    | ['block', 'branch']
+[no-suite-dupes][]      | 1, 'block'    | ['block', 'branch']
+[missing-expect][]      | 0, 'expect()' | expectation function names
 
 For example, the `no-focused-tests` rule is enabled by default and will cause
 ESLint to throw an error (with an exit code of `1`) when triggered.
@@ -55,6 +56,7 @@ See [configuring rules][] for more information.
 [no-disabled-tests]: docs/rules/no-disabled-tests.md
 [no-spec-dupes]: docs/rules/no-spec-dupes.md
 [no-suite-dupes]: docs/rules/no-suite-dupes.md
+[missing-expect]: docs/rules/missing-expect.md
 [configuring rules]: http://eslint.org/docs/user-guide/configuring#configuring-rules
 
 ## Author

--- a/docs/rules/missing-expect.md
+++ b/docs/rules/missing-expect.md
@@ -1,0 +1,46 @@
+# Enfore expectation (missing-expect)
+
+A test which doesn't make any expectations doesn't really test anything.
+
+## Rule details
+
+This rule triggers a warning if no expectations are made. This rule is disabled
+by default.
+
+An array of expect function names may be passed to the configuration of this
+rule. By default only `expect` is used.
+
+### Default configuration
+
+The following patterns are considered warnings:
+
+```js
+it('should do something', function() {});
+```
+
+The following patterns are not warnings:
+
+```js
+it('should do something', function() {
+  expect(something).toBeDone();
+});
+```
+
+### AngularJS `$httpBackend` example
+
+#### configuration
+
+```yaml
+rules:
+  missing-expect:
+    - 2
+    - expect()
+    - $httpBackend.expect()
+    - $httpBackend.expectDELETE()
+    - $httpBackend.expectGET()
+    - $httpBackend.expectJSONP()
+    - $httpBackend.expectHEAD()
+    - $httpBackend.expectPATCH()
+    - $httpBackend.expectPOST()
+    - $httpBackend.expectPUT()
+```

--- a/index.js
+++ b/index.js
@@ -5,12 +5,14 @@ module.exports = {
     'no-focused-tests': require('./lib/rules/no-focused-tests'),
     'no-disabled-tests': require('./lib/rules/no-disabled-tests'),
     'no-suite-dupes': require('./lib/rules/no-suite-dupes'),
-    'no-spec-dupes': require('./lib/rules/no-spec-dupes')
+    'no-spec-dupes': require('./lib/rules/no-spec-dupes'),
+    'missing-expect': require('./lib/rules/missing-expect')
   },
   rulesConfig: {
     'no-focused-tests': 2,
     'no-disabled-tests': 1,
     'no-suite-dupes': 1,
-    'no-spec-dupes': 1
+    'no-spec-dupes': 1,
+    'missing-expect': 0
   }
 };

--- a/lib/rules/missing-expect.js
+++ b/lib/rules/missing-expect.js
@@ -1,0 +1,52 @@
+'use strict';
+
+/**
+ * @fileoverview Enforce to make at least one expectation in an it block
+ * @author Remco Haszing
+ */
+
+module.exports = function(context) {
+
+  var allowed = context.options.length ? context.options : ['expect()'];
+
+  var unchecked = [];
+
+  function buildName(node) {
+    if (node.type === 'CallExpression') {
+      return buildName(node.callee) + '()';
+    }
+    if (node.type === 'MemberExpression') {
+      return buildName(node.object) + '.' + node.property.name;
+    }
+    if (node.type === 'Identifier') {
+      return node.name;
+    }
+  }
+
+  return {
+    CallExpression: function(node) {
+      if (node.callee.name === 'it') {
+        if (node.arguments.length > 1) {
+          unchecked.push(node);
+        }
+        return;
+      }
+      if (allowed.indexOf(buildName(node)) === -1) {
+        return;
+      }
+      context.getAncestors().some(function(ancestor) {
+        var index = unchecked.indexOf(ancestor);
+
+        if (index !== -1) {
+          unchecked.splice(index, 1);
+          return true;
+        }
+      });
+    },
+    'Program:exit': function() {
+      unchecked.forEach(function(node) {
+        context.report(node, 'Test has no expectations');
+      });
+    }
+  };
+};

--- a/test/rules/missing-expect.js
+++ b/test/rules/missing-expect.js
@@ -1,0 +1,90 @@
+'use strict';
+
+var rule = require('../../lib/rules/missing-expect');
+var RuleTester = require('eslint').RuleTester;
+
+var eslintTester = new RuleTester();
+
+eslintTester.run('missing-expect', rule, {
+  valid: [
+    'it("", function() {expect();})',
+    'it("", function() {expect().toBeSomething();})',
+    'it("", function() {return expect();})',
+    'it("", function() {if (foo) {expect();}})',
+    'it("", function() {if (foo) {} else {expect();}})',
+    'it("", function() {switch (foo) {case 1: expect()}})',
+    'it("", function() {async(function() {expect()})})',
+    'it("", function() {var foo = expect()})',
+    'it("")',
+    'it()',
+    {
+      code: 'it("", function() {$httpBackend.expectGET();})',
+      options: [
+        '$httpBackend.expectGET()'
+      ]
+    },
+    {
+      code: 'it("", function() {return $httpBackend.expectGET();})',
+      options: [
+        '$httpBackend.expectGET()'
+      ]
+    },
+    {
+      code: 'it("", function() {a.deeply.nested().expect.expression()})',
+      options: [
+        'a.deeply.nested().expect.expression()'
+      ]
+    }
+  ],
+
+  invalid: [
+    {
+      code: 'it("", function() {})',
+      errors: [
+        {
+          message: 'Test has no expectations'
+        }
+      ]
+    },
+    {
+      code: 'it("", function() {return;})',
+      errors: [
+        {
+          message: 'Test has no expectations'
+        }
+      ]
+    },
+    {
+      code: 'it("", function() {if (foo) {} else {}})',
+      errors: [
+        {
+          message: 'Test has no expectations'
+        }
+      ]
+    },
+    {
+      code: 'it("", function() {switch (foo) {case 1: break;}})',
+      errors: [
+        {
+          message: 'Test has no expectations'
+        }
+      ]
+    },
+    {
+      code: 'it("", function() {async(function() {});})',
+      errors: [
+        {
+          message: 'Test has no expectations'
+        }
+      ]
+    },
+    {
+      code: 'it("", function() {var foo = bar();})',
+      errors: [
+        {
+          message: 'Test has no expectations'
+        }
+      ]
+    }
+  ]
+});


### PR DESCRIPTION
This rule checks for it block which do not contain any expectations.