### PR TITLE
fix(no-focused-tests): only run on function calls

### DIFF
--- a/lib/prohibit.js
+++ b/lib/prohibit.js
@@ -4,8 +4,8 @@ module.exports = function(prohibiteds, context) {
   var regex = new RegExp('^(' + prohibiteds.join('|') + ')$');
 
   return {
-    'Identifier': function(node) {
-      var result = node.name.match(regex);
+    'CallExpression': function(node) {
+      var result = node.callee && node.callee.name.match(regex);
 
       if (result) {
         context.report(node, 'Unexpected {{name}}.', {

--- a/test/rules/no-disabled-tests.js
+++ b/test/rules/no-disabled-tests.js
@@ -8,7 +8,8 @@ var eslintTester = new RuleTester();
 eslintTester.run('no-disabled-tests', rule, {
   valid: [
     'describe("", function() {})',
-    'describe("", function() { it("", function() {} ) })'
+    'describe("", function() { it("", function() {} ) })',
+    'x = {a: xdescribe}'
   ],
 
   invalid: [
@@ -17,7 +18,7 @@ eslintTester.run('no-disabled-tests', rule, {
       errors: [
         {
           message: 'Unexpected xdescribe.',
-          type: 'Identifier'
+          type: 'CallExpression'
         }
       ]
     },
@@ -26,7 +27,7 @@ eslintTester.run('no-disabled-tests', rule, {
       errors: [
         {
           message: 'Unexpected xit.',
-          type: 'Identifier'
+          type: 'CallExpression'
         }
       ]
     }

--- a/test/rules/no-focused-tests.js
+++ b/test/rules/no-focused-tests.js
@@ -8,7 +8,8 @@ var eslintTester = new RuleTester();
 eslintTester.run('no-focused-tests', rule, {
   valid: [
     'describe("", function() {})',
-    'describe("", function() { it("", function() {} ) })'
+    'describe("", function() { it("", function() {} ) })',
+    'x = {a: ddescribe}'
   ],
 
   invalid: [
@@ -17,7 +18,7 @@ eslintTester.run('no-focused-tests', rule, {
       errors: [
         {
           message: 'Unexpected ddescribe.',
-          type: 'Identifier'
+          type: 'CallExpression'
         }
       ]
     },
@@ -26,7 +27,7 @@ eslintTester.run('no-focused-tests', rule, {
       errors: [
         {
           message: 'Unexpected iit.',
-          type: 'Identifier'
+          type: 'CallExpression'
         }
       ]
     },
@@ -35,7 +36,7 @@ eslintTester.run('no-focused-tests', rule, {
       errors: [
         {
           message: 'Unexpected fdescribe.',
-          type: 'Identifier'
+          type: 'CallExpression'
         }
       ]
     },
@@ -44,7 +45,7 @@ eslintTester.run('no-focused-tests', rule, {
       errors: [
         {
           message: 'Unexpected fit.',
-          type: 'Identifier'
+          type: 'CallExpression'
         }
       ]
     }


### PR DESCRIPTION
Hi,
right now, no-focused-tests and no-disabled-tests ran on every mention of 'ddescribe', 'fdescribe' etc.
This PR makes them only run when the prohibited function is called as a function.