### PR TITLE
feat(valid-expect): add valid-expect rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Rule                         | Default       | Options
 [no-suite-dupes][]           | 1, 'block'    | ['block', 'branch']
 [no-suite-callback-args][]   | 2             |
 [missing-expect][]           | 0, 'expect()' | expectation function names
+[valid-expect][]             | 1             |
 
 For example, the `no-focused-tests` rule is enabled by default and will cause
 ESLint to throw an error (with an exit code of `1`) when triggered.
@@ -59,6 +60,7 @@ See [configuring rules][] for more information.
 [no-suite-dupes]: docs/rules/no-suite-dupes.md
 [no-suite-callback-args]: docs/rules/no-suite-callback-args.md
 [missing-expect]: docs/rules/missing-expect.md
+[valid-expect]: docs/rules/valid-expect.md
 [configuring rules]: http://eslint.org/docs/user-guide/configuring#configuring-rules
 
 ## Author

--- a/docs/rules/valid-expect.md
+++ b/docs/rules/valid-expect.md
@@ -1,0 +1,27 @@
+# Enforce valid `expect()` usage (valid-expect)
+
+Ensure `expect()` is called with a single argument and there is an actual expectation made.
+
+## Rule details
+
+This rule triggers a warning if `expect()` is called with more than one argument or without arguments. 
+It would also issue a warning if there is nothing called on `expect()`.
+
+This rule is enabled by default.
+
+### Default configuration
+
+The following patterns are considered warnings:
+
+```js
+expect();
+expect().toEqual("something");
+expect("something", "else");
+expect("something");
+```
+
+The following patterns are not warnings:
+
+```js
+expect("something").toEqual("something");
+```

--- a/index.js
+++ b/index.js
@@ -7,7 +7,8 @@ module.exports = {
     'no-suite-dupes': require('./lib/rules/no-suite-dupes'),
     'no-spec-dupes': require('./lib/rules/no-spec-dupes'),
     'missing-expect': require('./lib/rules/missing-expect'),
-    'no-suite-callback-args': require('./lib/rules/no-suite-callback-args')
+    'no-suite-callback-args': require('./lib/rules/no-suite-callback-args'),
+    'valid-expect': require('./lib/rules/valid-expect')
   },
   rulesConfig: {
     'no-focused-tests': 2,
@@ -15,6 +16,7 @@ module.exports = {
     'no-suite-dupes': 1,
     'no-spec-dupes': 1,
     'missing-expect': 0,
-    'no-suite-callback-args': 2
+    'no-suite-callback-args': 2,
+    'valid-expect': 1
   }
 }

--- a/lib/rules/valid-expect.js
+++ b/lib/rules/valid-expect.js
@@ -1,0 +1,28 @@
+'use strict'
+
+/**
+ * @fileoverview Enforce valid expect() usage
+ * @author Alexander Afanasyev
+ */
+
+module.exports = function (context) {
+  return {
+    // checking "expect()" arguments
+    CallExpression: function (node) {
+      if (node.callee.name === 'expect') {
+        if (node.arguments.length > 1) {
+          context.report(node, 'More than one argument passed to expect()')
+        } else if (node.arguments.length === 0) {
+          context.report(node, 'No arguments passed to expect()')
+        }
+      }
+    },
+
+    // nothing called on "expect()"
+    'CallExpression:exit': function (node) {
+      if (node.callee.name === 'expect' && node.parent.type === 'ExpressionStatement') {
+        context.report(node, 'Nothing called on expect()')
+      }
+    }
+  }
+}

--- a/test/rules/valid-expect.js
+++ b/test/rules/valid-expect.js
@@ -1,0 +1,60 @@
+'use strict'
+
+var rule = require('../../lib/rules/valid-expect')
+var RuleTester = require('eslint').RuleTester
+
+var eslintTester = new RuleTester()
+
+eslintTester.run('valid-expect', rule, {
+  valid: [
+    'expect("something").toEqual("else");',
+    'expect(true).toBeDefined();',
+    'expect([1, 2, 3]).toEqual([1, 2, 3]);'
+  ],
+
+  invalid: [
+    {
+      code: 'expect().toBe(true);',
+      errors: [
+        {
+          message: 'No arguments passed to expect()'
+        }
+      ]
+    },
+    {
+      code: 'expect().toEqual("something");',
+      errors: [
+        {
+          message: 'No arguments passed to expect()'
+        }
+      ]
+    },
+    {
+      code: 'expect("something", "else").toEqual("something");',
+      errors: [
+        {
+          message: 'More than one argument passed to expect()'
+        }
+      ]
+    },
+    {
+      code: 'expect("something");',
+      errors: [
+        {
+          message: 'Nothing called on expect()'
+        }
+      ]
+    },
+    {
+      code: 'expect();',
+      errors: [
+        {
+          message: 'No arguments passed to expect()'
+        },
+        {
+          message: 'Nothing called on expect()'
+        }
+      ]
+    }
+  ]
+})


### PR DESCRIPTION
The rule ensures `expect()` is called with a single argument and there is an actual expectation made.

This rule triggers a warning if `expect()` is called with more than one argument or without arguments. 
It would also issue a warning if there is nothing called on `expect()`.