### PR TITLE
chore(package): remove rulesConfig and export a shareable config

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,23 @@ See [configuring rules][] for more information.
 [valid-expect]: docs/rules/valid-expect.md
 [configuring rules]: http://eslint.org/docs/user-guide/configuring#configuring-rules
 
+## Recommended configuration
+
+This plugin export a `recommended` configuration that enforce React good practices.
+
+To enable this configuration use the `extends` property in your `.eslintrc` config file:
+
+```js
+{
+  "plugins": [
+    "jasmine"
+  ],
+  "extends": "plugin:jasmine/recommended"
+}
+```
+
+See [ESLint documentation](http://eslint.org/docs/user-guide/configuring#extending-configuration-files) for more information about extending configuration files.
+
 ## Author
 
 © 2015 Tom Vincent <git@tlvince.com>

--- a/index.js
+++ b/index.js
@@ -11,14 +11,18 @@ module.exports = {
     'no-suite-callback-args': require('./lib/rules/no-suite-callback-args'),
     'valid-expect': require('./lib/rules/valid-expect')
   },
-  rulesConfig: {
-    'named-spy': 0,
-    'no-focused-tests': 2,
-    'no-disabled-tests': 1,
-    'no-suite-dupes': 1,
-    'no-spec-dupes': 1,
-    'missing-expect': 0,
-    'no-suite-callback-args': 2,
-    'valid-expect': 1
+  configs: {
+    recommended: {
+      rules: {
+        'named-spy': 0,
+        'no-focused-tests': 2,
+        'no-disabled-tests': 1,
+        'no-suite-dupes': 1,
+        'no-spec-dupes': 1,
+        'missing-expect': 0,
+        'no-suite-callback-args': 2,
+        'valid-expect': 1
+      }
+    }
   }
 }


### PR DESCRIPTION
With eslint 2.x support for [rulesConfig](http://eslint.org/blog/2016/02/eslint-v2.0.0-released#plugin-changes) has been removed. Plugins can now export shareable configs.