### PR TITLE
Report test/suite name in no-focused-tests and no-disabled-tests

### DIFF
--- a/lib/prohibit.js
+++ b/lib/prohibit.js
@@ -3,13 +3,66 @@
 module.exports = function (prohibiteds, context) {
   var regex = new RegExp('^(' + prohibiteds.join('|') + ')$')
 
+  var filterByNodeType = function (allowedNodeTypes) {
+    return function (node) {
+      return allowedNodeTypes.indexOf(node.type) > -1
+    }
+  }
+  var sortByProperty = function (propertyName) {
+    return function (a, b) {
+      if (a[propertyName] === b[propertyName]) {
+        return 0
+      }
+      return a[propertyName] > b[propertyName] ? 1 : -1
+    }
+  }
+  var wrapIn = function (wrapperStart, wrapperEnd) {
+    return function (value) {
+      return wrapperStart + value + (wrapperEnd || wrapperStart)
+    }
+  }
+
+  var stringifyLiterals = function (node) {
+    switch (node.type) {
+      case 'Literal':
+        return wrapIn('"')(node.value)
+      case 'TemplateLiteral':
+        return wrapIn('`')([]
+          .concat(node.expressions)
+          .concat(node.quasis)
+          .sort(sortByProperty('start'))
+          .map(stringifyTemplateLiteralComponent)
+          .join(''))
+    }
+  }
+
+  var stringifyTemplateLiteralComponent = function (node) {
+    switch (node.type) {
+      case 'TemplateElement':
+        return node.value.cooked
+
+      // Expressions
+      case 'Identifier':
+        return wrapIn('${ ', ' }')(node.name)
+      default:
+        return wrapIn('${ ', ' }')('<expression>')
+    }
+  }
+
   return {
     'CallExpression': function (node) {
       var result = node.callee && node.callee.name && node.callee.name.match(regex)
 
       if (result) {
-        context.report(node, 'Unexpected {{name}}.', {
-          name: result[1]
+        context.report(node, 'Unexpected {{name}}({{arg}})', {
+          name: result[1],
+          arg: node.arguments
+            .filter(filterByNodeType([
+              'Literal',
+              'TemplateLiteral'
+            ]))
+            .map(stringifyLiterals)
+            .join()
         })
       }
     }

--- a/test/rules/no-disabled-tests.js
+++ b/test/rules/no-disabled-tests.js
@@ -17,19 +17,47 @@ eslintTester.run('no-disabled-tests', rule, {
       code: 'xdescribe("My disabled suite", function() {});',
       errors: [
         {
-          message: 'Unexpected xdescribe.',
+          message: 'Unexpected xdescribe("My disabled suite")',
           type: 'CallExpression'
         }
       ]
     },
+    // TODO: enable this when parsing template literals succeeds
+    // Saw:
+    //
+    // AssertionError: A fatal parsing error occurred: Parsing error:
+    // Unexpected character '`'
+//    {
+//      code: 'xdescribe(`My disabled ${ suiteName }`, function() {});',
+//      errors: [
+//        {
+//          message: 'Unexpected xdescribe(\`My disabled ${ suiteName }\`)',
+//          type: 'CallExpression'
+//        }
+//      ]
+//    },
     {
       code: 'xit("My disabled spec", function() {});',
       errors: [
         {
-          message: 'Unexpected xit.',
+          message: 'Unexpected xit("My disabled spec")',
           type: 'CallExpression'
         }
       ]
     }
+    // TODO: enable this when parsing template literals succeeds
+    // Saw:
+    //
+    // AssertionError: A fatal parsing error occurred: Parsing error:
+    // Unexpected character '`'
+//    {
+//      code: 'xit(`My disabled ${ specName }`, function() {});',
+//      errors: [
+//        {
+//          message: 'Unexpected xit(`My disabled ${ specName }`)',
+//          type: 'CallExpression'
+//        }
+//      ]
+//    }
   ]
 })

--- a/test/rules/no-focused-tests.js
+++ b/test/rules/no-focused-tests.js
@@ -17,37 +17,93 @@ eslintTester.run('no-focused-tests', rule, {
       code: 'ddescribe("My exclusive suite", function() {});',
       errors: [
         {
-          message: 'Unexpected ddescribe.',
+          message: 'Unexpected ddescribe("My exclusive suite")',
           type: 'CallExpression'
         }
       ]
     },
+    // TODO: enable this when parsing template literals succeeds
+    // Saw:
+    //
+    // AssertionError: A fatal parsing error occurred: Parsing error:
+    // Unexpected character '`'
+//    {
+//      code: 'ddescribe(`My exclusive ${ suiteName }`, function() {});',
+//      errors: [
+//        {
+//          message: 'Unexpected ddescribe(`My exclusive ${ suiteName }`)',
+//          type: 'CallExpression'
+//        }
+//      ]
+//    },
     {
       code: 'iit("My exclusive test", function() {});',
       errors: [
         {
-          message: 'Unexpected iit.',
+          message: 'Unexpected iit("My exclusive test")',
           type: 'CallExpression'
         }
       ]
     },
+    // TODO: enable this when parsing template literals succeeds
+    // Saw:
+    //
+    // AssertionError: A fatal parsing error occurred: Parsing error:
+    // Unexpected character '`'
+//    {
+//      code: 'iit(`My exclusive ${ testName }`, function() {});',
+//      errors: [
+//        {
+//          message: 'Unexpected iit(`My exclusive ${ testName }`)',
+//          type: 'CallExpression'
+//        }
+//      ]
+//    },
     {
       code: 'fdescribe("My focused suite", function() {});',
       errors: [
         {
-          message: 'Unexpected fdescribe.',
+          message: 'Unexpected fdescribe("My focused suite")',
           type: 'CallExpression'
         }
       ]
     },
+    // TODO: enable this when parsing template literals succeeds
+    // Saw:
+    //
+    // AssertionError: A fatal parsing error occurred: Parsing error:
+    // Unexpected character '`'
+//    {
+//      code: 'fdescribe(`My exclusive ${ suiteName }`, function() {});',
+//      errors: [
+//        {
+//          message: 'Unexpected fdescribe(`My exclusive ${ suiteName }`)',
+//          type: 'CallExpression'
+//        }
+//      ]
+//    },
     {
       code: 'fit("My focused spec", function() {});',
       errors: [
         {
-          message: 'Unexpected fit.',
+          message: 'Unexpected fit("My focused spec")',
           type: 'CallExpression'
         }
       ]
     }
+    // TODO: enable this when parsing template literals succeeds
+    // Saw:
+    //
+    // AssertionError: A fatal parsing error occurred: Parsing error:
+    // Unexpected character '`'
+//    {
+//      code: 'fit(`My exclusive ${ testName }`, function() {});',
+//      errors: [
+//        {
+//          message: 'Unexpected fit(`My exclusive ${ testName }`)',
+//          type: 'CallExpression'
+//        }
+//      ]
+//    },
   ]
 })


### PR DESCRIPTION
@tlvince I managed to add test/suite name reporting for 2 rules using the prohibit helper.

Could you please take a look at why can't it parse template literals?
I tested it in one of my projects with the same prohibit code as I posted here and it works.