### PR TITLE
fix(named-spy): be more defensive to stop an exception if identifier …

### DIFF
--- a/lib/rules/named-spy.js
+++ b/lib/rules/named-spy.js
@@ -25,7 +25,7 @@ module.exports = function (context) {
       }
       if (!node.arguments.length || node.arguments[0].type !== 'Literal') {
         context.report(node, 'Unnamed spy')
-      } else if (node.arguments[0].value !== identifier.name) {
+      } else if (identifier && node.arguments[0].value !== identifier.name) {
         context.report(identifier, 'Variable should be named after the spy name')
       }
     }


### PR DESCRIPTION
I get lots of exceptions on my code base enabling the rule. I didn't work out the exact thing causing it but I fixed it by being more defensive..
