### PR TITLE
Adds no-unsafe-spy rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Rule                         | Recommended      | Options
 [no-suite-callback-args][]   | 2                |
 [valid-expect][]             | 1                |
 [no-assign-spyon][]          | 0                |
+[no-unsafe-spy][]            | 1                |
 
 For example, using the recommended configuration, the `no-focused-tests` rule
 is enabled and will cause ESLint to throw an error (with an exit code of `1`)
@@ -106,6 +107,7 @@ See [configuring rules][] for more information.
 [no-suite-callback-args]: docs/rules/no-suite-callback-args.md
 [valid-expect]: docs/rules/valid-expect.md
 [no-assign-spyon]: docs/rules/no-assign-spyon.md
+[no-unsafe-spy]: docs/rules/no-unsafe-spy.md
 
 [configuring rules]: http://eslint.org/docs/user-guide/configuring#configuring-rules
 

--- a/docs/rules/no-unsafe-spy.md
+++ b/docs/rules/no-unsafe-spy.md
@@ -1,0 +1,50 @@
+# Enforce spies to be defined in before/after/it blocks
+
+Make sure named spies are declared only in before/after/it jasmine blocks.
+Spies created in global scope or directly in define blocks don't
+get automatically reset/cleaned by the jasmine teardown process, making it possible
+to get false positives when using ```toHaveBeenCalled()``` / ```toHaveBeenCalledWith()```.
+
+## Rule details
+
+The following are considered warnings:
+
+```js
+// myFile.js
+var mySharedSpy = jasmine.createSpy()
+spyOn(someObj, "someMethod")
+
+describe(function () {
+  var mySharedSpy = jasmine.createSpy()
+  spyOn(someObj, "someMethod")
+})
+```
+
+The following patterns are not warnings:
+
+```js
+beforeEach(function () {
+  var mySpy = jasmine.createSpy()
+  spyOn(someObj, "someMethod")
+})
+
+beforeAll(function () {
+  var mySpy = jasmine.createSpy()
+  spyOn(someObj, "someMethod")
+})
+
+afterEach(function () {
+  var mySpy = jasmine.createSpy()
+  spyOn(someObj, "someMethod")
+})
+
+afterAll(function () {
+  var mySpy = jasmine.createSpy()
+  spyOn(someObj, "someMethod")
+})
+
+it(function () {
+  var mySpy = jasmine.createSpy()
+  spyOn(someObj, "someMethod")
+})
+```

--- a/index.js
+++ b/index.js
@@ -10,7 +10,8 @@ module.exports = {
     'missing-expect': require('./lib/rules/missing-expect'),
     'no-suite-callback-args': require('./lib/rules/no-suite-callback-args'),
     'valid-expect': require('./lib/rules/valid-expect'),
-    'no-assign-spyon': require('./lib/rules/no-assign-spyon')
+    'no-assign-spyon': require('./lib/rules/no-assign-spyon'),
+    'no-unsafe-spy': require('./lib/rules/no-unsafe-spy')
   },
   configs: {
     recommended: {
@@ -23,7 +24,8 @@ module.exports = {
         'jasmine/missing-expect': 0,
         'jasmine/no-suite-callback-args': 2,
         'jasmine/valid-expect': 1,
-        'jasmine/no-assign-spyon': 0
+        'jasmine/no-assign-spyon': 0,
+        'jasmine/no-unsafe-spy': 1
       }
     }
   }

--- a/lib/rules/no-unsafe-spy.js
+++ b/lib/rules/no-unsafe-spy.js
@@ -1,0 +1,36 @@
+'use strict'
+
+/**
+ * @fileoverview Enforce spies to be declared in before/after/it blocks
+ * @author Nicolas Fernandez @burabure
+ */
+
+var blocksWhitelistRegexp = /^(f|d|x)?(before\w+|after\w+|it)$/
+
+function getParentJasmineBlock (ancestors) {
+  for (var i = (ancestors.length - 1); i > 0; i--) {
+    if (
+      ancestors[i].type === 'CallExpression' &&
+      blocksWhitelistRegexp.test(ancestors[i].callee.name)
+    ) { return ancestors[i].callee.name }
+  }
+  return false
+}
+
+module.exports = function (context) {
+  return {
+    CallExpression: function (node) {
+      if (
+        node.callee.name !== 'spyOn' &&
+        !(
+          (node.callee.object && node.callee.object.name === 'jasmine') &&
+          (node.callee.property && node.callee.property.name === 'createSpy')
+        )
+      ) { return }
+
+      if (blocksWhitelistRegexp.test(getParentJasmineBlock(context.getAncestors()))) { return }
+
+      context.report(node, 'Spy declared outside of before/after/it block')
+    }
+  }
+}

--- a/test/helpers/lines_to_code.js
+++ b/test/helpers/lines_to_code.js
@@ -1,0 +1,13 @@
+/*
+ * Generate readble code lines block
+ * // description
+ * lines[0]
+ * lines[1]
+ * ...
+ * lines[n]
+ */
+function linesToCode (lines, description) {
+  return (description ? '// ' + description : '') + '\n' + lines.join('\n')
+}
+
+module.exports = linesToCode

--- a/test/rules/no-suite-dupes.js
+++ b/test/rules/no-suite-dupes.js
@@ -1,43 +1,32 @@
 'use strict'
 
 var rule = require('../../lib/rules/no-suite-dupes')
+var linesToCode = require('../helpers/lines_to_code')
 var RuleTester = require('eslint').RuleTester
 
 var eslintTester = new RuleTester()
 
-/*
- * Generate readble code lines block
- * // description
- * lines[0]
- * lines[1]
- * ...
- * lines[n]
- */
-function toCode (lines, description) {
-  return (description ? '// ' + description : '') + '\n' + lines.join('\n')
-}
-
 eslintTester.run('no-suite-dupes', rule, {
   valid: [
     // default
-    toCode([
+    linesToCode([
       'describe("The first suite name", function() {}); ',
       'describe("The second suite name", function() {})'
     ]),
-    toCode([
+    linesToCode([
       'unrelated("The first spec name", function() {}); ',
       'unrelated("The second spec name", function() {})'
     ], 'unrelated'),
-    toCode([
+    linesToCode([
       // used to cause bug
       'justAFunction();'
     ], 'a regular function'),
-    toCode([
+    linesToCode([
       'describe("Handling" + " string " + "concatenation", function() {}); ',
       'describe("Handling" + " it good", function() {})'
     ], 'description is concatenated string'),
     {
-      code: toCode([
+      code: linesToCode([
         'describe("Some context", function() {',
         '  // it(...',
         '});',
@@ -52,7 +41,7 @@ eslintTester.run('no-suite-dupes', rule, {
       options: [
         'block'
       ],
-      code: toCode([
+      code: linesToCode([
         'describe("The first suite name", function() {}); ',
         'describe("The second suite name", function() {})'
       ])
@@ -63,7 +52,7 @@ eslintTester.run('no-suite-dupes', rule, {
       options: [
         'branch'
       ],
-      code: toCode([
+      code: linesToCode([
         'describe("The first suite name", function() {}); ',
         'describe("The second suite name", function() {})'
       ])
@@ -72,7 +61,7 @@ eslintTester.run('no-suite-dupes', rule, {
       options: [
         'branch'
       ],
-      code: toCode([
+      code: linesToCode([
         'describe("unique", function(){',
         '  // it(...',
         '});',
@@ -85,7 +74,7 @@ eslintTester.run('no-suite-dupes', rule, {
       options: [
         'branch'
       ],
-      code: toCode([
+      code: linesToCode([
         'describe("context", function(){',
         '  describe("unique", function(){',
         '    // it(...',
@@ -100,7 +89,7 @@ eslintTester.run('no-suite-dupes', rule, {
       options: [
         'branch'
       ],
-      code: toCode([
+      code: linesToCode([
         'describe("same", function(){',
         '  describe("same", function(){',
         '    // it(...',
@@ -112,7 +101,7 @@ eslintTester.run('no-suite-dupes', rule, {
   invalid: [
     {
       // default
-      code: toCode([
+      code: linesToCode([
         'describe("Same suite name", function() {});',
         'describe("Same suite name", function() {})'
       ]),
@@ -124,7 +113,7 @@ eslintTester.run('no-suite-dupes', rule, {
       ]
     },
     {
-      code: toCode([
+      code: linesToCode([
         'describe("Handling" + " string " + "concatenation", function() {}); ',
         'describe("Handling string concatenation", function() {})'
       ], 'description is concatenated string'),
@@ -141,7 +130,7 @@ eslintTester.run('no-suite-dupes', rule, {
       options: [
         'block'
       ],
-      code: toCode([
+      code: linesToCode([
         'describe("Same suite name", function() {}); ',
         'describe("Same suite name", function() {})'
       ]),
@@ -156,7 +145,7 @@ eslintTester.run('no-suite-dupes', rule, {
       options: [
         'block'
       ],
-      code: toCode([
+      code: linesToCode([
         'describe("Parent context", function(){',
         '  describe("Same block", function(){',
         '    describe("Same block", function(){',
@@ -178,7 +167,7 @@ eslintTester.run('no-suite-dupes', rule, {
       options: [
         'branch'
       ],
-      code: toCode([
+      code: linesToCode([
         'describe("Same suite name", function() {}); ',
         'describe("Same suite name", function() {})'
       ], 'same blocks'),
@@ -193,7 +182,7 @@ eslintTester.run('no-suite-dupes', rule, {
       options: [
         'branch'
       ],
-      code: toCode([
+      code: linesToCode([
         'describe("parent context", function(){',
         '  describe("same", function(){',
         '    // it(...',
@@ -214,7 +203,7 @@ eslintTester.run('no-suite-dupes', rule, {
       options: [
         'branch'
       ],
-      code: toCode([
+      code: linesToCode([
         'describe("parent context", function(){',
         '  describe("same", function(){',
         '    // it(...',

--- a/test/rules/no-unsafe-spy.js
+++ b/test/rules/no-unsafe-spy.js
@@ -1,0 +1,81 @@
+'use strict'
+
+var rule = require('../../lib/rules/no-unsafe-spy')
+var linesToCode = require('../helpers/lines_to_code')
+var RuleTester = require('eslint').RuleTester
+
+var eslintTester = new RuleTester()
+
+eslintTester.run('no-unsafe-spy', rule, {
+  valid: [
+    // beforeEach block
+    linesToCode([
+      'beforeEach(function () {',
+      '  var mySpy = jasmine.createSpy()',
+      '  spyOn(someObj, "someMethod")',
+      '})'
+    ]),
+    // beforeAll block
+    linesToCode([
+      'beforeAll(function () {',
+      '  var mySpy = jasmine.createSpy()',
+      '  spyOn(someObj, "someMethod")',
+      '})'
+    ]),
+    // afterEach block
+    linesToCode([
+      'afterEach(function () {',
+      '  var mySpy = jasmine.createSpy()',
+      '  spyOn(someObj, "someMethod")',
+      '})'
+    ]),
+    // afterAll block
+    linesToCode([
+      'afterAll(function () {',
+      '  var mySpy = jasmine.createSpy()',
+      '  spyOn(someObj, "someMethod")',
+      '})'
+    ]),
+    // it block
+    linesToCode([
+      'it(function () {',
+      '  var mySpy = jasmine.createSpy()',
+      '  spyOn(someObj, "someMethod")',
+      '})'
+    ])
+  ],
+  invalid: [
+    {
+      code: 'var mySharedSpy = jasmine.createSpy()',
+      errors: [
+        {message: 'Spy declared outside of before/after/it block'}
+      ]
+    },
+    {
+      code: 'spyOn(someObj, "someMethod")',
+      errors: [
+        {message: 'Spy declared outside of before/after/it block'}
+      ]
+    },
+    {
+      code: linesToCode([
+        'describe(function () {',
+        '  var mySharedSpy = jasmine.createSpy()',
+        '})'
+      ]),
+      errors: [
+        {message: 'Spy declared outside of before/after/it block'}
+      ]
+    },
+    {
+      code: linesToCode([
+        'describe(function () {',
+        '  spyOn(someObj, "someMethod")',
+        '})'
+      ]),
+      errors: [
+        {message: 'Spy declared outside of before/after/it block'}
+      ]
+    }
+  ]
+})


### PR DESCRIPTION
no-unsafe-spy enforces spies to be defined in before/after/it blocks, see https://github.com/burabure/eslint-plugin-jasmine/blob/276894f486c953ec9ed6b9ab4bc667328ce83d78/docs/rules/no-unsafe-spy.md
