### PR TITLE
Fixed multiple cases when named-spy gave errors name of undefined

### DIFF
--- a/lib/rules/named-spy.js
+++ b/lib/rules/named-spy.js
@@ -11,22 +11,43 @@ module.exports = function (context) {
       if (node.callee.type !== 'MemberExpression') {
         return
       }
+
       if (node.callee.property.name !== 'createSpy') {
         return
       }
+
       if (node.callee.object.name !== 'jasmine') {
         return
       }
-      var identifier
-      if (node.parent.type === 'VariableDeclarator') {
-        identifier = node.parent.id
-      } else if (node.parent.type === 'AssignmentExpression') {
-        identifier = node.parent.left
+
+      var identifier = findIdentifier(node)
+
+      if (node.arguments.length) {
+        console.log(node.arguments[0].value)
       }
+
       if (!node.arguments.length || node.arguments[0].type !== 'Literal') {
         context.report(node, 'Unnamed spy')
       } else if (node.arguments[0].value !== identifier.name) {
         context.report(identifier, 'Variable should be named after the spy name')
+      }
+
+      function findIdentifier (node) {
+        var parent = node.parent
+        while (parent) {
+          if (parent.type === 'VariableDeclarator') {
+            return parent.id
+          } else if (parent.type === 'Property') {
+            return parent.key
+          } else if (parent.type === 'AssignmentExpression' && parent.left) {
+            if (parent.left.type === 'Identifier') {
+              return parent.left
+            } else if (parent.left.property && parent.left.property.type === 'Identifier') {
+              return parent.left.property
+            }
+          }
+          parent = parent.parent
+        }
       }
     }
   }

--- a/lib/rules/named-spy.js
+++ b/lib/rules/named-spy.js
@@ -22,10 +22,6 @@ module.exports = function (context) {
 
       var identifier = findIdentifier(node)
 
-      if (node.arguments.length) {
-        console.log(node.arguments[0].value)
-      }
-
       if (!node.arguments.length || node.arguments[0].type !== 'Literal') {
         context.report(node, 'Unnamed spy')
       } else if (node.arguments[0].value !== identifier.name) {

--- a/test/rules/named-spy.js
+++ b/test/rules/named-spy.js
@@ -1,6 +1,7 @@
 'use strict'
 
 var rule = require('../../lib/rules/named-spy')
+var linesToCode = require('../helpers/lines_to_code')
 var RuleTester = require('eslint').RuleTester
 
 var eslintTester = new RuleTester()
@@ -17,7 +18,22 @@ eslintTester.run('named-spy', rule, {
     'other = library.createSpy("onSuccess")',
     // Correct use of named spies
     'var onSuccess = jasmine.createSpy("onSuccess")',
-    'onSuccess = jasmine.createSpy("onSuccess")'
+    'onSuccess = jasmine.createSpy("onSuccess")',
+    linesToCode([
+      'someObject = {',
+      '  someFunc: jasmine.createSpy("someFunc")',
+      '};'
+    ]),
+    linesToCode([
+      'someObject = {',
+      '  someFunc: jasmine.createSpy("someFunc").and.callThrough()',
+      '};'
+    ]),
+    linesToCode([
+      'function someFunc() {',
+      '  this.spy = jasmine.createSpy("spy").and.callThrough()',
+      '};'
+    ])
   ],
   invalid: [
     {
@@ -40,6 +56,36 @@ eslintTester.run('named-spy', rule, {
     },
     {
       code: 'spy = jasmine.createSpy("callback")',
+      errors: [
+        {message: 'Variable should be named after the spy name'}
+      ]
+    },
+    {
+      code: linesToCode([
+        'someObject = {',
+        '  spy: jasmine.createSpy("someFunc")',
+        '};'
+      ]),
+      errors: [
+        {message: 'Variable should be named after the spy name'}
+      ]
+    },
+    {
+      code: linesToCode([
+        'someObject = {',
+        '  spy: jasmine.createSpy("someFunc").and.callThrough()',
+        '};'
+      ]),
+      errors: [
+        {message: 'Variable should be named after the spy name'}
+      ]
+    },
+    {
+      code: linesToCode([
+        'function someFunc() {',
+        '  this.spy = jasmine.createSpy("someSpy").and.callThrough()',
+        '};'
+      ]),
       errors: [
         {message: 'Variable should be named after the spy name'}
       ]


### PR DESCRIPTION
I have jasmine.createSpy() in various ways written. When running the rule named-spy gives fatal errors because the identifier is not correctly found stopping the entire linting. This PR tries to limit the cases in which it doesn't find it.