### PR TITLE
fix(valid-expect): members after expect are not recognized

### DIFF
--- a/lib/rules/valid-expect.js
+++ b/lib/rules/valid-expect.js
@@ -17,7 +17,8 @@ module.exports = function (context) {
         }
 
         // matcher was not called
-        if (node.parent && node.parent.parent && node.parent.parent.type !== 'CallExpression') {
+        if (node.parent && node.parent.parent && node.parent.parent.type !== 'CallExpression' &&
+          node.parent.parent.type !== 'MemberExpression') {
           context.report(node, 'Matcher was not called')
         }
       }

--- a/test/rules/valid-expect.js
+++ b/test/rules/valid-expect.js
@@ -9,7 +9,8 @@ eslintTester.run('valid-expect', rule, {
   valid: [
     'expect("something").toEqual("else");',
     'expect(true).toBeDefined();',
-    'expect([1, 2, 3]).toEqual([1, 2, 3]);'
+    'expect([1, 2, 3]).toEqual([1, 2, 3]);',
+    'expect(undefined).not.toBeDefined();'
   ],
 
   invalid: [


### PR DESCRIPTION
valid-expect gives false negatives. For example: expect(true).not.toBe(false) . this gives Matcher was not called when it should be valid. This PR solves this.