### PR TITLE
docs: adding new-line-between-declarations to config table

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,20 +64,22 @@ configuration files.
 
 ### Rules
 
-Rule                            | Recommended      | Options
-----                            | -----------      | -------
-[named-spy][]                   | 0                |
-[no-focused-tests][]            | 2                |
-[no-disabled-tests][]           | 1                |
-[no-suite-dupes][]              | 1, `'block'`     | `['block', 'branch']`
-[no-spec-dupes][]               | 1, `'block'`     | `['block', 'branch']`
-[missing-expect][]              | 0, `'expect()'`  | expectation function names
-[no-suite-callback-args][]      | 2                |
-[valid-expect][]                | 1                |
-[no-assign-spyon][]             | 0                |
-[no-unsafe-spy][]               | 1                |
-[no-global-setup][]             | 2                |
-[no-expect-in-setup-teardown][] | 1, `'expect()'`  | expectation function names
+Rule                              | Recommended      | Options
+----                              | -----------      | -------
+[named-spy][]                     | 0                |
+[no-focused-tests][]              | 2                |
+[no-disabled-tests][]             | 1                |
+[no-suite-dupes][]                | 1, `'block'`     | `['block', 'branch']`
+[no-spec-dupes][]                 | 1, `'block'`     | `['block', 'branch']`
+[missing-expect][]                | 0, `'expect()'`  | expectation function names
+[no-suite-callback-args][]        | 2                |
+[valid-expect][]                  | 1                |
+[no-assign-spyon][]               | 0                |
+[no-unsafe-spy][]                 | 1                |
+[no-global-setup][]               | 2                |
+[no-expect-in-setup-teardown][]   | 1, `'expect()'`  | expectation function names
+[new-line-between-declarations][] | 1                |
+
 
 For example, using the recommended configuration, the `no-focused-tests` rule
 is enabled and will cause ESLint to throw an error (with an exit code of `1`)

--- a/docs/rules/new-line-between-declarations.md
+++ b/docs/rules/new-line-between-declarations.md
@@ -26,8 +26,10 @@ describe("", function() {
 });
 ```
 ```js
-describe("", function() {});
-describe("", function() {});
+describe("", function() {
+  describe("", function() {});
+  describe("", function() {});
+});
 ```
 
 The following patterns are not warnings:


### PR DESCRIPTION
Quick follow up to the new-line-between-declarations rule. 
