### PR TITLE
fix: update context.report() calls

### DIFF
--- a/lib/helpers/no-dupes.js
+++ b/lib/helpers/no-dupes.js
@@ -65,8 +65,10 @@ module.exports = function (kind, branchBlocks, checkedBlocks) {
           }
 
           if (suites.indexOf(suite) !== -1) {
-            context.report(node, 'Duplicate ' + kind + ': "{{suite}}"', {
-              suite: suite
+            context.report({
+              data: { kind, suite },
+              message: 'Duplicate {{kind}}: "{{suite}}"',
+              node
             })
           }
           suites.push(suite)

--- a/lib/helpers/prohibit.js
+++ b/lib/helpers/prohibit.js
@@ -8,8 +8,12 @@ module.exports = function (prohibiteds, context) {
       var result = node.callee && node.callee.name && node.callee.name.match(regex)
 
       if (result) {
-        context.report(node, 'Unexpected {{name}}.', {
-          name: result[1]
+        context.report({
+          data: {
+            name: result[1]
+          },
+          message: 'Unexpected {{name}}.',
+          node
         })
       }
     }

--- a/lib/rules/missing-expect.js
+++ b/lib/rules/missing-expect.js
@@ -34,7 +34,10 @@ module.exports = function (context) {
     },
     'Program:exit': function () {
       unchecked.forEach(function (node) {
-        context.report(node, 'Test has no expectations')
+        context.report({
+          message: 'Test has no expectations',
+          node
+        })
       })
     }
   }

--- a/lib/rules/named-spy.js
+++ b/lib/rules/named-spy.js
@@ -39,12 +39,18 @@ module.exports = function (context) {
       }
 
       if (!node.arguments.length || node.arguments[0].type !== 'Literal') {
-        return context.report(node, 'Unnamed spy')
+        return context.report({
+          message: 'Unnamed spy',
+          node
+        })
       }
 
       var identifier = findIdentifier(node)
       if (identifier && node.arguments[0].value !== identifier.name) {
-        return context.report(identifier, 'Variable should be named after the spy name')
+        return context.report({
+          message: 'Variable should be named after the spy name',
+          node: identifier
+        })
       }
     }
   }

--- a/lib/rules/new-line-before-expect.js
+++ b/lib/rules/new-line-before-expect.js
@@ -23,11 +23,11 @@ module.exports = function (context) {
           }
           if (!hasPaddingBetweenTokens(prevToken, node)) {
             context.report({
-              node,
-              message: 'No new line before expect',
               fix (fixer) {
                 return fixer.insertTextBefore(node, '\n')
-              }
+              },
+              message: 'No new line before expect',
+              node
             })
           }
         }

--- a/lib/rules/new-line-between-declarations.js
+++ b/lib/rules/new-line-between-declarations.js
@@ -24,11 +24,11 @@ module.exports = function (context) {
       }
       if (declWithoutPadding) {
         context.report({
-          node,
-          message: 'No new line between declarations',
           fix (fixer) {
             return fixer.insertTextAfter(declWithoutPadding, '\n')
-          }
+          },
+          message: 'No new line between declarations',
+          node
         })
       }
     }

--- a/lib/rules/no-assign-spyon.js
+++ b/lib/rules/no-assign-spyon.js
@@ -9,7 +9,10 @@ module.exports = function (context) {
   return {
     CallExpression: function (node) {
       if (node.callee.name === 'spyOn' && (node.parent.type === 'AssignmentExpression' || node.parent.type === 'VariableDeclarator')) {
-        context.report(node, 'The result of spyOn() should not be assigned')
+        context.report({
+          message: 'The result of spyOn() should not be assigned',
+          node
+        })
       }
     }
   }

--- a/lib/rules/no-describe-variables.js
+++ b/lib/rules/no-describe-variables.js
@@ -6,7 +6,10 @@
  */
 
 function report (context, node) {
-  context.report(node, 'Test has variable declaration in the describe block')
+  context.report({
+    message: 'Test has variable declaration in the describe block',
+    node
+  })
 }
 
 module.exports = function (context) {

--- a/lib/rules/no-expect-in-setup-teardown.js
+++ b/lib/rules/no-expect-in-setup-teardown.js
@@ -25,7 +25,11 @@ module.exports = function (context) {
       if (insideSetup) {
         var functionName = buildName(node)
         if (allowed.indexOf(functionName) > -1) {
-          context.report(node, 'Unexpected "' + functionName + '" call in "' + setupFunctionName + '()"')
+          context.report({
+            data: { functionName, setupFunctionName },
+            message: 'Unexpected "{{functionName}}" call in "{{setupFunctionName}}()"',
+            node
+          })
         }
       }
     },

--- a/lib/rules/no-global-setup.js
+++ b/lib/rules/no-global-setup.js
@@ -15,7 +15,13 @@ module.exports = function (context) {
       if (suiteRegexp.test(node.callee.name)) {
         suiteDepth++
       } else if (setupRegexp.test(node.callee.name) && suiteDepth === 0) {
-        context.report(node, 'Do not use `' + node.callee.name + '` outside a `describe`.')
+        context.report({
+          data: {
+            name: node.callee.name
+          },
+          message: 'Do not use `{{name}}` outside a `describe`.',
+          node
+        })
       }
     },
     'CallExpression:exit': function (node) {

--- a/lib/rules/no-suite-callback-args.js
+++ b/lib/rules/no-suite-callback-args.js
@@ -14,7 +14,10 @@ module.exports = function (context) {
         var arg = node.arguments[1]
 
         if (arg.type === 'FunctionExpression' && arg.params.length) {
-          context.report(node, "Unexpected argument in suite's callback")
+          context.report({
+            message: "Unexpected argument in suite's callback",
+            node
+          })
         }
       }
     }

--- a/lib/rules/no-unsafe-spy.js
+++ b/lib/rules/no-unsafe-spy.js
@@ -33,7 +33,10 @@ module.exports = function (context) {
 
       if (blocksWhitelistRegexp.test(getParentJasmineBlock(context.getAncestors()))) { return }
 
-      context.report(node, 'Spy declared outside of before/after/it block')
+      context.report({
+        message: 'Spy declared outside of before/after/it block',
+        node
+      })
     }
   }
 }

--- a/lib/rules/prefer-jasmine-matcher.js
+++ b/lib/rules/prefer-jasmine-matcher.js
@@ -19,8 +19,8 @@ module.exports = function (context) {
         var expectNode = node.arguments && node.arguments[0]
         if (expectNode.type === 'BinaryExpression' && operators.indexOf(expectNode.operator) > -1) {
           context.report({
-            node,
-            message: 'Prefer jasmine matcher instead of comparison'
+            message: 'Prefer jasmine matcher instead of comparison',
+            node
           })
         }
       }

--- a/lib/rules/valid-expect.js
+++ b/lib/rules/valid-expect.js
@@ -11,15 +11,24 @@ module.exports = function (context) {
       if (node.callee.name === 'expect') {
         // checking "expect()" arguments
         if (node.arguments.length > 1) {
-          context.report(node, 'More than one argument passed to expect()')
+          context.report({
+            message: 'More than one argument passed to expect()',
+            node
+          })
         } else if (node.arguments.length === 0) {
-          context.report(node, 'No arguments passed to expect()')
+          context.report({
+            message: 'No arguments passed to expect()',
+            node
+          })
         }
 
         // matcher was not called
         if (node.parent && node.parent.parent && node.parent.parent.type !== 'CallExpression' &&
           node.parent.parent.type !== 'MemberExpression') {
-          context.report(node, 'Matcher was not called')
+          context.report({
+            message: 'Matcher was not called',
+            node
+          })
         }
       }
     },
@@ -27,7 +36,10 @@ module.exports = function (context) {
     // nothing called on "expect()"
     'CallExpression:exit': function (node) {
       if (node.callee.name === 'expect' && node.parent.type === 'ExpressionStatement') {
-        context.report(node, 'Nothing called on expect()')
+        context.report({
+          message: 'Nothing called on expect()',
+          node
+        })
       }
     }
   }


### PR DESCRIPTION
To be conform with documented usage.
 - http://eslint.org/docs/developer-guide/working-with-rules

Closes #132.
