### PR TITLE
fix(no-global-setup): allow global setup in helpers

### DIFF
--- a/docs/rules/no-global-setup.md
+++ b/docs/rules/no-global-setup.md
@@ -2,6 +2,9 @@
 
 Make sure that all uses of the global `beforeEach`, `afterEach`, `beforeAll`, and `afterAll` methods are within a suite.
 
+The only appropriate use of these methods in a global context is within jasmine helpers where the intent of the global definition is explicit (e.g. setting up globally applied matchers).
+See example: [/jasmine/jasmine/lib/jasmine-core/example/node_example/spec/helpers/jasmine_examples/SpecHelper.js](https://github.com/jasmine/jasmine/blob/8624a52ee0b6f13b3b608ea6417ccc02257c5412/lib/jasmine-core/example/node_example/spec/helpers/jasmine_examples/SpecHelper.js)
+
 ## Rule details
 
 The following are considered warnings:

--- a/lib/rules/no-global-setup.js
+++ b/lib/rules/no-global-setup.js
@@ -35,7 +35,6 @@ module.exports = function (context) {
       }
     },
     'Program:exit': function () {
-      console.log('---> globalNodes: ' + globalSetupNodes)
       if (hasGlobalSetup && hasRootSuite) {
         for (var i = 0, nodeDetail, len = globalSetupNodes.length; i < len; i++) {
           nodeDetail = globalSetupNodes[i]

--- a/lib/rules/no-global-setup.js
+++ b/lib/rules/no-global-setup.js
@@ -10,24 +10,36 @@ var setupRegexp = /^(before|after)(Each|All)$/
 
 module.exports = function (context) {
   var suiteDepth = 0
+  var hasGlobalSetup = false
+  var hasRootSuite = false
+  var globalSetupNames = []
   return {
     CallExpression: function (node) {
-      console.log(context)
       if (suiteRegexp.test(node.callee.name)) {
+        hasRootSuite = true
         suiteDepth++
       } else if (setupRegexp.test(node.callee.name) && suiteDepth === 0) {
-        context.report({
-          data: {
-            name: node.callee.name
-          },
-          message: 'Do not use `{{name}}` outside a `describe`.',
-          node
-        })
+        hasGlobalSetup = true
+        globalSetupNames.push(node.callee.name)
       }
     },
     'CallExpression:exit': function (node) {
       if (suiteRegexp.test(node.callee.name)) {
         suiteDepth--
+      }
+    },
+    'Program:exit': function () {
+      if (hasGlobalSetup && hasRootSuite) {
+        context.report({
+          data: {
+            names: globalSetupNames.join(', ')
+          },
+          message: 'Do not use `{{names}}` outside a `describe` except for in global helpers.',
+          loc: {
+            line: 1,
+            column: 0
+          }
+        })
       }
     }
   }

--- a/lib/rules/no-global-setup.js
+++ b/lib/rules/no-global-setup.js
@@ -12,7 +12,7 @@ module.exports = function (context) {
   var suiteDepth = 0
   var hasGlobalSetup = false
   var hasRootSuite = false
-  var globalSetupNames = []
+  var globalSetupNodes = []
   return {
     CallExpression: function (node) {
       if (suiteRegexp.test(node.callee.name)) {
@@ -20,7 +20,13 @@ module.exports = function (context) {
         suiteDepth++
       } else if (setupRegexp.test(node.callee.name) && suiteDepth === 0) {
         hasGlobalSetup = true
-        globalSetupNames.push(node.callee.name)
+        globalSetupNodes.push({
+          name: node.callee.name,
+          loc: {
+            line: node.loc.line,
+            column: node.loc.column
+          }
+        })
       }
     },
     'CallExpression:exit': function (node) {
@@ -29,17 +35,18 @@ module.exports = function (context) {
       }
     },
     'Program:exit': function () {
+      console.log('---> globalNodes: ' + globalSetupNodes)
       if (hasGlobalSetup && hasRootSuite) {
-        context.report({
-          data: {
-            names: globalSetupNames.join(', ')
-          },
-          message: 'Do not use `{{names}}` outside a `describe` except for in global helpers.',
-          loc: {
-            line: 1,
-            column: 0
-          }
-        })
+        for (var i = 0, nodeDetail, len = globalSetupNodes.length; i < len; i++) {
+          nodeDetail = globalSetupNodes[i]
+          context.report({
+            data: {
+              name: nodeDetail.name
+            },
+            message: 'Do not use `{{name}}` outside a `describe` except for in global helpers.',
+            loc: nodeDetail.loc
+          })
+        }
       }
     }
   }

--- a/lib/rules/no-global-setup.js
+++ b/lib/rules/no-global-setup.js
@@ -12,6 +12,7 @@ module.exports = function (context) {
   var suiteDepth = 0
   return {
     CallExpression: function (node) {
+      console.log(context)
       if (suiteRegexp.test(node.callee.name)) {
         suiteDepth++
       } else if (setupRegexp.test(node.callee.name) && suiteDepth === 0) {

--- a/test/rules/no-global-setup.js
+++ b/test/rules/no-global-setup.js
@@ -19,14 +19,15 @@ eslintTester.run('no-global-setup', rule, {
       message: 'Do not use `beforeEach` outside a `describe` except for in global helpers.'
     }]
   }, {
-    code: 'afterEach(function() {}); describe(function() {})',
+    code: 'beforeEach(function() {}); afterEach(function() {}); beforeAll(function() {}); afterAll(function() {}); describe(function() {})',
     errors: [{
+      message: 'Do not use `beforeEach` outside a `describe` except for in global helpers.'
+    }, {
       message: 'Do not use `afterEach` outside a `describe` except for in global helpers.'
-    }]
-  }, {
-    code: 'beforeEach(function() {}); describe(function() {}); afterEach(function() {})',
-    errors: [{
-      message: 'Do not use `beforeEach, afterEach` outside a `describe` except for in global helpers.'
+    }, {
+      message: 'Do not use `beforeAll` outside a `describe` except for in global helpers.'
+    }, {
+      message: 'Do not use `afterAll` outside a `describe` except for in global helpers.'
     }]
   }]
 })

--- a/test/rules/no-global-setup.js
+++ b/test/rules/no-global-setup.js
@@ -9,18 +9,24 @@ eslintTester.run('no-global-setup', rule, {
   valid: [{
     code: 'describe("", function() { beforeEach(function() {}) })'
   }, {
-    code: 'beforeEach(function() {})',
-    filename: 'tests/helpers/mocks/mockBeforeEachHelper.js'
+    code: 'beforeEach(function() {})'
+  }, {
+    code: 'beforeEach(function() {}); afterEach(function() {})'
   }],
   invalid: [{
-    code: 'beforeEach(function() {})',
+    code: 'beforeEach(function() {}); describe(function() {})',
     errors: [{
-      message: 'Do not use `beforeEach` outside a `describe`.'
+      message: 'Do not use `beforeEach` outside a `describe` except for in global helpers.'
     }]
   }, {
-    code: 'afterEach(function() {})',
+    code: 'afterEach(function() {}); describe(function() {})',
     errors: [{
-      message: 'Do not use `afterEach` outside a `describe`.'
+      message: 'Do not use `afterEach` outside a `describe` except for in global helpers.'
+    }]
+  }, {
+    code: 'beforeEach(function() {}); describe(function() {}); afterEach(function() {})',
+    errors: [{
+      message: 'Do not use `beforeEach, afterEach` outside a `describe` except for in global helpers.'
     }]
   }]
 })

--- a/test/rules/no-global-setup.js
+++ b/test/rules/no-global-setup.js
@@ -6,17 +6,21 @@ var RuleTester = require('eslint').RuleTester
 var eslintTester = new RuleTester()
 
 eslintTester.run('no-global-setup', rule, {
-  valid: [
-    'describe("", function() { beforeEach(function() {}) })'
-  ],
-  invalid: [
-    {
-      code: 'beforeEach(function() {})',
-      errors: [{message: 'Do not use `beforeEach` outside a `describe`.'}]
-    },
-    {
-      code: 'afterEach(function() {})',
-      errors: [{message: 'Do not use `afterEach` outside a `describe`.'}]
-    }
-  ]
+  valid: [{
+    code: 'describe("", function() { beforeEach(function() {}) })'
+  }, {
+    code: 'beforeEach(function() {})',
+    filename: 'tests/helpers/mocks/mockBeforeEachHelper.js'
+  }],
+  invalid: [{
+    code: 'beforeEach(function() {})',
+    errors: [{
+      message: 'Do not use `beforeEach` outside a `describe`.'
+    }]
+  }, {
+    code: 'afterEach(function() {})',
+    errors: [{
+      message: 'Do not use `afterEach` outside a `describe`.'
+    }]
+  }]
 })


### PR DESCRIPTION
Refinement to allow the inclusion of global setup blocks in situations where now root-level 'describe' suite blocks are defined (e.g. global jasmine helpers).

For full discussion, see: https://github.com/tlvince/eslint-plugin-jasmine/issues/29#issuecomment-318201806