### PR TITLE
fix(new-line-before-expect): maintain expectation indentation

### DIFF
--- a/lib/helpers/getLineIndentation.js
+++ b/lib/helpers/getLineIndentation.js
@@ -1,0 +1,18 @@
+/**
+ * The column number of the first token on the line
+ * @author James Brennan
+ *
+ * @param {Node} node The node to read location information from
+ * @param {SourceCode} sourceCode The SourceCode object for the file
+ * @returns {number} The column number of the first token on the line
+ */
+
+var getPrevTokensOnLine = require('./getPrevTokensOnLine')
+
+function getLineIndentation (node, sourceCode) {
+  var prevTokens = getPrevTokensOnLine(node, sourceCode)
+  var first = prevTokens.length ? prevTokens[0] : node
+  return first.loc.start.column
+}
+
+module.exports = getLineIndentation

--- a/lib/helpers/getPrevTokensOnLine.js
+++ b/lib/helpers/getPrevTokensOnLine.js
@@ -1,0 +1,19 @@
+/**
+ * @fileoverview Returns an array containing the tokens preceding a node on the same line
+ * @author James Brennan
+ * @param {Node} node The node to read location information from
+ * @param {SourceCode} sourceCode The SourceCode object for the file
+ * @returns {Token[]} An array containing tokens on the same line, ordered left to right
+*/
+
+function getPrevTokensOnLine (node, sourceCode) {
+  var prevToken = sourceCode.getTokenBefore(node)
+  var tokens = []
+  while (prevToken.loc.end.line === node.loc.start.line) {
+    tokens.unshift(prevToken)
+    prevToken = sourceCode.getTokenBefore(prevToken)
+  }
+  return tokens
+}
+
+module.exports = getPrevTokensOnLine

--- a/lib/rules/new-line-before-expect.js
+++ b/lib/rules/new-line-before-expect.js
@@ -6,6 +6,8 @@
 */
 
 var hasPaddingBetweenTokens = require('../helpers/hasPaddingBetweenTokens')
+var getPrevTokensOnLine = require('../helpers/getPrevTokensOnLine')
+var getLineIndentation = require('../helpers/getLineIndentation')
 
 var blockRegexp = /^((f|x)?(it|describe))$/
 
@@ -23,15 +25,19 @@ module.exports = function (context) {
           return
         }
         lastExpectNode = node
-        const prevToken = context.getSourceCode().getTokenBefore(node)
+        var sourceCode = context.getSourceCode()
+        const prevToken = sourceCode.getTokenBefore(node)
         if (prevToken) {
           if (prevToken.type === 'Punctuator' && prevToken.value === '{') {
             return
           }
-          if (!hasPaddingBetweenTokens(prevToken, node)) {
+          if (!hasPaddingBetweenTokens(prevToken, node) && isFirstExpectOnLine(node, sourceCode)) {
             context.report({
               fix (fixer) {
-                return fixer.insertTextBefore(node, '\n')
+                return fixer.replaceTextRange(
+                  [prevToken.range[1], node.range[1]],
+                  ['\n\n', withIndentation(node, sourceCode)].join('')
+                )
               },
               message: 'No new line before expect',
               node
@@ -50,4 +56,19 @@ module.exports = function (context) {
 
 function linesDelta (node1, node2) {
   return Math.abs(node1.loc.start.line - node2.loc.start.line)
+}
+
+function isFirstExpectOnLine (node, sourceCode) {
+  return getPrevTokensOnLine(node, sourceCode)
+          .filter(token => token.value === 'expect')
+          .length === 0
+}
+
+function withIndentation (node, sourceCode) {
+  let indentation = getLineIndentation(node, sourceCode)
+  let text = [sourceCode.getText(node)]
+  for (var i = 0; i < indentation; i++) {
+    text.unshift(' ')
+  }
+  return text.join('')
 }

--- a/test/rules/new-line-before-expect.js
+++ b/test/rules/new-line-before-expect.js
@@ -49,6 +49,13 @@ eslintTester.run('new line before expect', rule, {
       '}));'
     ]),
     linesToCode([
+      'it("", helper(function() {',
+      '  var a = 1',
+      '',
+      '  expect(a).toBe(1); expect(a).not.toBe(0);',
+      '}));'
+    ]),
+    linesToCode([
       'notJasmineTestSuite()',
       'expect(a)'
     ]),
@@ -84,7 +91,8 @@ eslintTester.run('new line before expect', rule, {
         'describe("", function() {',
         ' it("", function(){',
         '  var a = 1',
-        '  \nexpect(1).toBe(1)',
+        '',
+        '  expect(1).toBe(1)',
         ' });',
         '});'
       ])
@@ -104,8 +112,77 @@ eslintTester.run('new line before expect', rule, {
       output: linesToCode([
         'it("", helper(function() {',
         '  var a = 1',
-        '  \nexpect(a).toEqual(1);',
+        '',
+        '  expect(a).toEqual(1);',
         '}));'
+      ])
+    },
+    {
+      code: linesToCode([
+        'it("", helper(function() {',
+        '  var a = 1',
+        '  var b = 2',
+        '  expect(a).toEqual(1); expect(b).toEqual(2);',
+        '}));'
+      ]),
+      errors: [
+        {
+          message: 'No new line before expect'
+        }
+      ],
+      output: linesToCode([
+        'it("", helper(function() {',
+        '  var a = 1',
+        '  var b = 2',
+        '',
+        '  expect(a).toEqual(1); expect(b).toEqual(2);',
+        '}));'
+      ])
+    },
+    {
+      code: linesToCode([
+        'describe("", function() {',
+        ' it("", function(){',
+        '  var a = 1; expect(a).toBe(1)',
+        ' });',
+        '});'
+      ]),
+      errors: [
+        {
+          message: 'No new line before expect'
+        }
+      ],
+      output: linesToCode([
+        'describe("", function() {',
+        ' it("", function(){',
+        '  var a = 1;',
+        '',
+        '  expect(a).toBe(1)',
+        ' });',
+        '});'
+      ])
+    },
+    {
+      code: linesToCode([
+        'describe("", function() {',
+        ' it("", function(){',
+        '  var a = 1; expect(a).toBe(1); expect(a).not.toBe(0);',
+        ' });',
+        '});'
+      ]),
+      errors: [
+        {
+          message: 'No new line before expect'
+        }
+      ],
+      output: linesToCode([
+        'describe("", function() {',
+        ' it("", function(){',
+        '  var a = 1;',
+        '',
+        '  expect(a).toBe(1); expect(a).not.toBe(0);',
+        ' });',
+        '});'
       ])
     }
   ]


### PR DESCRIPTION
Currently the fix for `new-line-before-expect` will remove the indentation of the expect line.

This:
```javascript
describe("", function() {
  it("", function(){
    var a = 1
    expect(1).toBe(1)
  });
});
```

Is transformed to this:
```javascript
describe("", function() {
  it("", function(){
    var a = 1
    
expect(1).toBe(1)
  });
});
```

This PR updates the behavior so that the indentation is preserved, like this:
```javascript
describe("", function() {
  it("", function(){
    var a = 1
    
    expect(1).toBe(1)
  });
});
```
