### PR TITLE
fix(no-describe-variables): Track variables declaration also in arrow functions

### DIFF
--- a/lib/rules/no-describe-variables.js
+++ b/lib/rules/no-describe-variables.js
@@ -16,6 +16,9 @@ module.exports = function (context) {
   return {
     'CallExpression[callee.name="describe"] > FunctionExpression > BlockStatement > VariableDeclaration': report.bind(this, context),
     'CallExpression[callee.name="xdescribe"] > FunctionExpression > BlockStatement > VariableDeclaration': report.bind(this, context),
-    'CallExpression[callee.name="fdescribe"] > FunctionExpression > BlockStatement > VariableDeclaration': report.bind(this, context)
+    'CallExpression[callee.name="fdescribe"] > FunctionExpression > BlockStatement > VariableDeclaration': report.bind(this, context),
+    'CallExpression[callee.name="describe"] > ArrowFunctionExpression > BlockStatement > VariableDeclaration': report.bind(this, context),
+    'CallExpression[callee.name="xdescribe"] > ArrowFunctionExpression > BlockStatement > VariableDeclaration': report.bind(this, context),
+    'CallExpression[callee.name="fdescribe"] > ArrowFunctionExpression > BlockStatement > VariableDeclaration': report.bind(this, context)
   }
 }

--- a/test/rules/no-describe-variables.js
+++ b/test/rules/no-describe-variables.js
@@ -3,13 +3,20 @@
 var rule = require('../../lib/rules/no-describe-variables')
 var RuleTester = require('eslint').RuleTester
 
-var eslintTester = new RuleTester()
+var eslintTester = new RuleTester({
+  "parserOptions": {
+    "ecmaVersion": 6
+  }
+})
 
 eslintTester.run('no-describe-variables', rule, {
   valid: [
     'describe("My suite", function() { it("works", function() {}); });',
     'xdescribe("My suite", function() { it("works", function() {}); });',
-    'fdescribe("My suite", function() { it("works", function() {}); });'
+    'fdescribe("My suite", function() { it("works", function() {}); });',
+    'describe("My suite", () => { it("works", function() {}); });',
+    'xdescribe("My suite", () => { it("works", function() {}); });',
+    'fdescribe("My suite", () => { it("works", function() {}); });',
   ],
   invalid: [
     {
@@ -30,6 +37,14 @@ eslintTester.run('no-describe-variables', rule, {
     },
     {
       code: 'xdescribe("My suite", function() { var x; beforeEach(function () { x = 5; }); it("works", function() {}); });',
+      errors: [
+        {
+          message: 'Test has variable declaration in the describe block'
+        }
+      ]
+    },
+    {
+      code: 'describe("My suite", () => { var x; it("works", () => {}); });',
       errors: [
         {
           message: 'Test has variable declaration in the describe block'


### PR DESCRIPTION
Following code is reported as correct for "no-describe-variables" rule, but should throw an error.

```js
describe("My suite", () => { 
  var x; 
  it("works", () => {
     // ...
  })
})
```

This pull request fixes the issue by checking also arrow functions.