### PR TITLE
fix(new-line-between-declarations): Add extra check for arguments body

### DIFF
--- a/lib/rules/new-line-between-declarations.js
+++ b/lib/rules/new-line-between-declarations.js
@@ -43,7 +43,7 @@ module.exports = function (context) {
 function getDescribeDeclarationsContent (describe) {
   var declartionsRegexp = /^(((before|after)(Each|All))|^(f|x)?(it|describe))$/
   var declarations = []
-  if (describe.arguments && describe.arguments[1] && describe.arguments[1].body.body) {
+  if (describe.arguments && describe.arguments[1] && describe.arguments[1].body && describe.arguments[1].body.body) {
     var content = describe.arguments[1].body.body
     content.forEach(node => {
       if (node.type === 'ExpressionStatement' && node.expression.callee && declartionsRegexp.test(node.expression.callee.name)) {


### PR DESCRIPTION
Closes #156 

I tried to add a test case, for this scenario like this: 
```
    {
      code: linesToCode([
        ' describe("", function() {})',
        ' describe("", function)'
      ]),
      errors: [
        {
          message: 'A fatal parsing error occurred: Parsing error: Unexpected token )'
        }
      ],
      output: linesToCode([
        'describe("", function() {})',
        'describe("", function)'
      ])
    }
```
But the `RuleTester` throws fatal parsing error which i am not sure how to handle. Perhaps you know how I can get around that? (i looked for some docs re `RuleTester` but couldn't really find any)

Some testing in VSCode does indicate the problem is resolved by this change though...