### PR TITLE
fix(rule): allow done.fail in first argument of then

### DIFF
--- a/docs/rules/no-promise-without-done-fail.md
+++ b/docs/rules/no-promise-without-done-fail.md
@@ -34,10 +34,25 @@ describe('A suite', function(done) {
 
 describe('A suite', function(done) {
   it('A spec', function() {
+    asyncCall().then(done.fail, onError);
+  });
+});
+
+describe('A suite', function(done) {
+  it('A spec', function() {
     asyncCall().then(function() {
       expect(true).toBe(true);
       done();
     }).catch(done.fail);
+  });
+});
+
+describe('A suite', function(done) {
+  it('A spec', function() {
+    asyncCall().then(done.fail).catch(function() {
+      expect(true).toBe(true);
+      done();
+    });
   });
 });
 ```

--- a/lib/rules/no-promise-without-done-fail.js
+++ b/lib/rules/no-promise-without-done-fail.js
@@ -12,18 +12,23 @@ function hasIdentifier (node, property) {
     node.callee.property.name === property
 }
 
-function hasDoneFailInReject (node, asyncParam) {
-  var reject = node.arguments[1]
+function hasDoneFail (reject, asyncParam) {
   return reject &&
     reject.type === 'MemberExpression' &&
     reject.object.type === 'Identifier' && reject.object.name === asyncParam &&
     reject.property.type === 'Identifier' && reject.property.name === 'fail'
 }
 
+function hasDoneFailArgument (node, asyncParam) {
+  var resolve = node.arguments[0]
+  var reject = node.arguments[1]
+  return hasDoneFail(resolve, asyncParam) || hasDoneFail(reject, asyncParam)
+}
+
 function isPromiseThenWithoutCatch (node, asyncParam) {
   return hasIdentifier(node, 'then') &&
     !hasIdentifier(node.parent.parent, 'then') &&
-    !hasDoneFailInReject(node, asyncParam) &&
+    !hasDoneFailArgument(node, asyncParam) &&
     !hasIdentifier(node.parent.parent, 'catch')
 }
 

--- a/test/rules/no-promise-without-done-fail.js
+++ b/test/rules/no-promise-without-done-fail.js
@@ -22,6 +22,9 @@ ruleTester.run('no-promise-without-done-fail', rule, {
       code: 'it("", function (done) { asyncFunc.then(done, done.fail);})'
     },
     {
+      code: 'it("", function (done) { asyncFunc.then(done.fail, done);})'
+    },
+    {
       code: 'it("should not care about the name of the first parameter", function (finished) { somethingAsync().then(finished, finished.fail);});'
     },
     {
@@ -37,6 +40,9 @@ ruleTester.run('no-promise-without-done-fail', rule, {
       code: 'it("", (done) => { asyncFunc.then(done, done.fail);})'
     },
     {
+      code: 'it("", (done) => { asyncFunc.then(done.fail, done);})'
+    },
+    {
       code: 'it("should not care about the name of the first parameter", (finished) => { somethingAsync().then(finished, finished.fail);});'
     },
     {
@@ -46,6 +52,12 @@ ruleTester.run('no-promise-without-done-fail', rule, {
   invalid: [
     {
       code: 'it("", function(done) { somethingAsync.then(function(res) { expect(res).toBe(true); done(); }) })',
+      errors: [{
+        message: 'An "it" that uses an async method should handle failure (use "done.fail")'
+      }]
+    },
+    {
+      code: 'it("", function(done) { somethingAsync.then(undefined, function(err) { expect(err).toBe(true); done(); }) })',
       errors: [{
         message: 'An "it" that uses an async method should handle failure (use "done.fail")'
       }]


### PR DESCRIPTION
This updates the `no-promise-without-done-fail` rule to allow `done.fail` to be the first argument passed to a promises `then` method. This allows for test that validate the reject callback to also require the done.fail.
