### PR TITLE
fix(expect-matcher): verify expect() is in MemberExpression

### DIFF
--- a/lib/rules/expect-matcher.js
+++ b/lib/rules/expect-matcher.js
@@ -9,8 +9,13 @@ module.exports = function (context) {
     CallExpression: function (node) {
       if (node.callee.name === 'expect') {
         // matcher was not called
-        if (node.parent && node.parent.parent && node.parent.parent.type !== 'CallExpression' &&
-          node.parent.parent.type !== 'MemberExpression') {
+        if (
+          node.parent &&
+          node.parent.parent &&
+          (node.parent.type !== 'MemberExpression' ||
+            (node.parent.parent.type !== 'CallExpression' &&
+              node.parent.parent.type !== 'MemberExpression'))
+        ) {
           context.report({
             message: 'Expect must have a corresponding matcher call.',
             node

--- a/test/rules/expect-matcher.js
+++ b/test/rules/expect-matcher.js
@@ -3,14 +3,15 @@
 var rule = require('../../lib/rules/expect-matcher')
 var RuleTester = require('eslint').RuleTester
 
-var eslintTester = new RuleTester()
+var eslintTester = new RuleTester({ parserOptions: { ecmaVersion: 2015 } })
 
 eslintTester.run('expect-matcher', rule, {
   valid: [
     'expect("something").toEqual("else");',
     'expect(true).toBeDefined();',
     'expect([1, 2, 3]).toEqual([1, 2, 3]);',
-    'expect(undefined).not.toBeDefined();'
+    'expect(undefined).not.toBeDefined();',
+    'it("something", () => expect(null).toBeFalsy());'
   ],
 
   invalid: [
@@ -32,6 +33,14 @@ eslintTester.run('expect-matcher', rule, {
     },
     {
       code: 'expect(true).toBeDefined;',
+      errors: [
+        {
+          message: 'Expect must have a corresponding matcher call.'
+        }
+      ]
+    },
+    {
+      code: 'it("something", () => expect(null));',
       errors: [
         {
           message: 'Expect must have a corresponding matcher call.'


### PR DESCRIPTION
fixes #174 

The fix makes sure that `expect()` is being used as part of a `MemberExpression`.