### PR TITLE
Include eslint metadata in rule definitions (new-line-before-expect)

### DIFF
--- a/docs/rules/new-line-before-expect.md
+++ b/docs/rules/new-line-before-expect.md
@@ -5,7 +5,7 @@ If `expect` is the first statement inside a test then rule is not enforced.
 
 ## Rule details
 
-This rule triggers a **warning** (is set to **1** by default) whenever there is no new line or another except before expect.
+This rule triggers a **warning** (is set to **1** by default) whenever there is no new line or another expect before expect.
 
 The following pattern is considered a warning:
 

--- a/lib/rules/new-line-before-expect.js
+++ b/lib/rules/new-line-before-expect.js
@@ -11,44 +11,57 @@ var getLineIndentation = require('../helpers/getLineIndentation')
 
 var blockRegexp = /^((f|x)?(it|describe))$/
 
-module.exports = function (context) {
-  var suiteDepth = 0
-  var lastExpectNode
-  return {
-    CallExpression: function (node) {
-      if (blockRegexp.test(node.callee.name)) {
-        lastExpectNode = null
-        suiteDepth++
-      } else if (node.callee.name === 'expect' && suiteDepth > 0) {
-        if (lastExpectNode && linesDelta(node, lastExpectNode) === 1) {
-          lastExpectNode = node
-          return
-        }
-        lastExpectNode = node
-        var sourceCode = context.getSourceCode()
-        const prevToken = sourceCode.getTokenBefore(node)
-        if (prevToken) {
-          if (prevToken.type === 'Punctuator' && prevToken.value === '{') {
+module.exports = {
+  meta: {
+    docs: {
+      description: 'enforce new line before expect inside a suite',
+      category: 'Stylistic Issues'
+    },
+    fixable: 'whitespace',
+    schema: [],
+    messages: {
+      noNewLine: 'No new line before expect'
+    }
+  },
+  create: context => {
+    var suiteDepth = 0
+    var lastExpectNode
+    return {
+      CallExpression: function (node) {
+        if (blockRegexp.test(node.callee.name)) {
+          lastExpectNode = null
+          suiteDepth++
+        } else if (node.callee.name === 'expect' && suiteDepth > 0) {
+          if (lastExpectNode && linesDelta(node, lastExpectNode) === 1) {
+            lastExpectNode = node
             return
           }
-          if (!hasPaddingBetweenTokens(prevToken, node) && isFirstExpectOnLine(node, sourceCode)) {
-            context.report({
-              fix (fixer) {
-                return fixer.replaceTextRange(
-                  [prevToken.range[1], node.range[1]],
-                  ['\n\n', withIndentation(node, sourceCode)].join('')
-                )
-              },
-              message: 'No new line before expect',
-              node
-            })
+          lastExpectNode = node
+          var sourceCode = context.getSourceCode()
+          const prevToken = sourceCode.getTokenBefore(node)
+          if (prevToken) {
+            if (prevToken.type === 'Punctuator' && prevToken.value === '{') {
+              return
+            }
+            if (!hasPaddingBetweenTokens(prevToken, node) && isFirstExpectOnLine(node, sourceCode)) {
+              context.report({
+                fix (fixer) {
+                  return fixer.replaceTextRange(
+                    [prevToken.range[1], node.range[1]],
+                    ['\n\n', withIndentation(node, sourceCode)].join('')
+                  )
+                },
+                messageId: 'noNewLine',
+                node
+              })
+            }
           }
         }
-      }
-    },
-    'CallExpression:exit': function (node) {
-      if (blockRegexp.test(node.callee.name)) {
-        suiteDepth--
+      },
+      'CallExpression:exit': function (node) {
+        if (blockRegexp.test(node.callee.name)) {
+          suiteDepth--
+        }
       }
     }
   }


### PR DESCRIPTION
### SUMMARY

When exporting rules, include the associated eslint-style metadata (description, category, etc.).

Specifying type of `fixable` (code/whitespace) doesn't matter today, but may matter in the future.

Specifying an explicit schema can help identify mistakes (for example, a user accidentally specifying options on a rule that does not support it, like `"new-line-before-expect": ["error", "always"]` will now get an error when they run eslint).

I'd like to see this metadata added to every rule.  I'm throwing up a PR for one rule to test the waters and see if you have any concerns!

### REVIEWERS

- You can [turn whitespace off](https://github.com/tlvince/eslint-plugin-jasmine/pull/182/files?w=1) to see just the changed lines.

### TESTS

- No test changes / all tests pass.