### PR TITLE
Propose rule: prefer-toBeUndefined

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Rule                              | Recommended                        | Options
 [valid-expect][]                  | `deprecated`                       |
 [prefer-jasmine-matcher][]        | 1                                  |
 [prefer-toHaveBeenCalledWith][]   | 1                                  |
+[prefer-toBeUndefined][]          | 0                                  | `['always', 'never']`
 
 
 For example, using the recommended configuration, the `no-focused-tests` rule
@@ -129,6 +130,7 @@ See [configuring rules][] for more information.
 [valid-expect]: docs/rules/valid-expect.md
 [prefer-jasmine-matcher]: docs/rules/prefer-jasmine-matcher.md
 [prefer-toHaveBeenCalledWith]: docs/rules/prefer-toHaveBeenCalledWith.md
+[prefer-toBeUndefined]: docs/rules/prefer-toBeUndefined.md
 
 [configuring rules]: http://eslint.org/docs/user-guide/configuring#configuring-rules
 

--- a/docs/rules/prefer-toBeUndefined.md
+++ b/docs/rules/prefer-toBeUndefined.md
@@ -1,0 +1,51 @@
+# Prefer toBeUndefined
+
+This rule recommends using `toBeUndefined` instead of the more generic matcher
+`toBe(undefined)`.
+
+## Rule details
+
+This rule forces a codebase to be consistent when expecting values to be
+`undefined` in unit tests.
+
+## Options
+
+### always
+
+The `"always"` option (default) prefers `toBeUndefined()`. Select this option
+if you'd like developers to use a matcher that tests specifically for
+`undefined`.
+
+Examples of *incorrect* code for the `"always"` option:
+
+```js
+expect(value).toBe(undefined);
+expect(value).toBe(undefined, 'with an explanation');
+```
+
+Examples of *correct* code for the `"always"` option:
+
+```js
+expect(value).toBeUndefined();
+expect(value).toBeUndefined('with an explanation');
+```
+
+### never
+
+The `"never"` option prefers `toBe(undefined)`. Select this option if you'd
+like developers to use the `toBe` matcher consistently, whether testing
+for `undefined` or not.
+
+Examples of *incorrect* code for the `"never"` option:
+
+```js
+expect(value).toBeUndefined();
+expect(value).toBeUndefined('with an explanation');
+```
+
+Examples of *correct* code for the `"never"` option:
+
+```js
+expect(value).toBe(undefined);
+expect(value).toBe(undefined, 'with an explanation');
+```

--- a/index.js
+++ b/index.js
@@ -44,7 +44,8 @@ module.exports = {
         'jasmine/new-line-between-declarations': 1,
         'jasmine/new-line-before-expect': 1,
         'jasmine/prefer-jasmine-matcher': 1,
-        'jasmine/prefer-toHaveBeenCalledWith': 1
+        'jasmine/prefer-toHaveBeenCalledWith': 1,
+        'jasmine/prefer-toBeUndefined': 0
       }
     }
   }

--- a/lib/rules/prefer-toBeUndefined.js
+++ b/lib/rules/prefer-toBeUndefined.js
@@ -1,0 +1,55 @@
+'use strict'
+
+/**
+ * @fileoverview Prefer toBeUndefined instead of toBe(undefined)
+ * @author Elliot Nelson
+ */
+
+module.exports = {
+  meta: {
+    schema: [
+      {
+        enum: ['always', 'never']
+      }
+    ],
+    fixable: 'code'
+  },
+  create: function (context) {
+    const always = context.options[0] !== 'never'
+
+    return {
+      'CallExpression': function (node) {
+        if (always) {
+          if (node.callee.type === 'MemberExpression' && node.callee.property.name === 'toBe' &&
+              node.arguments[0] && node.arguments[0].name === 'undefined') {
+            context.report({
+              message: 'Prefer toBeUndefined() to expect undefined',
+              node: node.callee.property,
+              fix: function (fixer) {
+                if (node.arguments.length === 1) {
+                  return fixer.replaceTextRange([node.callee.property.start, node.arguments[0].end], 'toBeUndefined(')
+                } else {
+                  return fixer.replaceTextRange([node.callee.property.start, node.arguments[1].start], 'toBeUndefined(')
+                }
+              }
+            })
+          }
+        } else {
+          if (node.callee.type === 'MemberExpression' && node.callee.property.name === 'toBeUndefined') {
+            context.report({
+              message: 'Prefer toBe(undefined) to expect undefined',
+              node: node.callee.property,
+              fix: function (fixer) {
+                if (node.arguments.length === 0) {
+                  return fixer.replaceTextRange([node.callee.property.start, node.end], 'toBe(undefined)')
+                } else {
+                  return fixer.replaceTextRange([node.callee.property.start, node.arguments[0].start], 'toBe(undefined, ')
+                }
+              }
+            })
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/rules/prefer-toBeUndefined.js
+++ b/test/rules/prefer-toBeUndefined.js
@@ -1,0 +1,107 @@
+'use strict'
+
+var rule = require('../../lib/rules/prefer-toBeUndefined')
+var linesToCode = require('../helpers/lines_to_code')
+var RuleTester = require('eslint').RuleTester
+
+var eslintTester = new RuleTester()
+
+eslintTester.run('prefer toBeUndefined', rule, {
+  valid: [
+    {
+      code: linesToCode([
+        'expect(x).toBeUndefined();'
+      ])
+    },
+    {
+      code: linesToCode([
+        'expect(x).toBeUndefined("with an optional message");'
+      ])
+    },
+    {
+      options: ['never'],
+      code: linesToCode([
+        'expect(x).toBe(undefined);'
+      ])
+    },
+    {
+      options: ['never'],
+      code: linesToCode([
+        'expect(x).toBe(undefined, "with an optional message");'
+      ])
+    }
+  ],
+  invalid: [
+    {
+      code: linesToCode([
+        'expect(x).toBe(undefined);'
+      ]),
+      output: linesToCode([
+        'expect(x).toBeUndefined();'
+      ]),
+      errors: [
+        {
+          message: 'Prefer toBeUndefined() to expect undefined'
+        }
+      ]
+    },
+    {
+      code: linesToCode([
+        'expect(x).toBe(undefined, "with an optional message", "???");'
+      ]),
+      output: linesToCode([
+        'expect(x).toBeUndefined("with an optional message", "???");'
+      ]),
+      errors: [
+        {
+          message: 'Prefer toBeUndefined() to expect undefined'
+        }
+      ]
+    },
+    {
+      code: linesToCode([
+        'expect(x).toBe(',
+        '  undefined,',
+        '  "why would you do this?"',
+        ');'
+      ]),
+      output: linesToCode([
+        'expect(x).toBeUndefined("why would you do this?"',
+        ');'
+      ]),
+      errors: [
+        {
+          message: 'Prefer toBeUndefined() to expect undefined'
+        }
+      ]
+    },
+    {
+      options: ['never'],
+      code: linesToCode([
+        'expect(x).toBeUndefined();'
+      ]),
+      output: linesToCode([
+        'expect(x).toBe(undefined);'
+      ]),
+      errors: [
+        {
+          message: 'Prefer toBe(undefined) to expect undefined'
+        }
+      ]
+    },
+    {
+      options: ['never'],
+      code: linesToCode([
+        'expect(x).toBeUndefined("with optional args", "???");'
+      ]),
+      output: linesToCode([
+        'expect(x).toBe(undefined, "with optional args", "???");'
+      ]),
+      errors: [
+        {
+          message: 'Prefer toBe(undefined) to expect undefined'
+        }
+      ]
+    }
+  ]
+})


### PR DESCRIPTION
### SUMMARY

Add rule `prefer-toBeUndefined`, which prefers developers use the more specific `toBeUndefined()` matcher instead of the more generic `toBe(undefined)`.  (Or, optionally, to prefer the reverse.)

> _Note:_ I see the issue now with `messageIds`, there is a bug in `eslint` 4.0.0 that causes the RuleTester to fail when you use messageIds.  At some point a chore to update the version of eslint would be nice (if not to 5, then at least the latest version of 4), but for now I'll just use the `message` option directly.

### TESTS

- New spec added.