### PR TITLE
Propose rule: require asynchronous callback param to be named 'done'

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Rule                              | Recommended                        | Options
 [valid-expect][]                  | `deprecated`                       |
 [prefer-jasmine-matcher][]        | 1                                  |
 [prefer-toHaveBeenCalledWith][]   | 1                                  |
+[prefer-spec-callback-done][]     | 0                                  |
 
 
 For example, using the recommended configuration, the `no-focused-tests` rule
@@ -129,6 +130,7 @@ See [configuring rules][] for more information.
 [valid-expect]: docs/rules/valid-expect.md
 [prefer-jasmine-matcher]: docs/rules/prefer-jasmine-matcher.md
 [prefer-toHaveBeenCalledWith]: docs/rules/prefer-toHaveBeenCalledWith.md
+[prefer-spec-callback-done]: docs/rules/prefer-spec-callback-done.md
 
 [configuring rules]: http://eslint.org/docs/user-guide/configuring#configuring-rules
 

--- a/docs/rules/prefer-spec-callback-done.md
+++ b/docs/rules/prefer-spec-callback-done.md
@@ -1,0 +1,37 @@
+# Prefer spec callbacks be named `done` (prefer-spec-callback-done)
+
+This rule recommends that asynchronous tests that receive a callback function
+always name this parameter `done`.
+
+## Rule details
+
+This rule checks that specs that do have a parameter always name that parameter
+`done`. You can enable this rule if you have differing standards on a codebase
+and would like to have all asynchronous callbacks be consistently named.
+
+Examples of *incorrect* code for this rule:
+
+```js
+it('returns the expected value', function (testComplete) {
+  testComplete();
+});
+
+it('returns the expected value', finished => {
+  finished();
+});
+```
+
+Examples of *correct* code for this rule:
+
+```js
+it('returns the expected value', function (done) {
+  done();
+});
+
+it('returns the expected value', done => {
+  done();
+});
+
+it('returns the expected value', function () {
+});
+```

--- a/index.js
+++ b/index.js
@@ -21,7 +21,8 @@ module.exports = {
     'new-line-between-declarations': require('./lib/rules/new-line-between-declarations'),
     'new-line-before-expect': require('./lib/rules/new-line-before-expect'),
     'prefer-jasmine-matcher': require('./lib/rules/prefer-jasmine-matcher'),
-    'prefer-toHaveBeenCalledWith': require('./lib/rules/prefer-toHaveBeenCalledWith')
+    'prefer-toHaveBeenCalledWith': require('./lib/rules/prefer-toHaveBeenCalledWith'),
+    'prefer-spec-callback-done': require('./lib/rules/prefer-spec-callback-done')
   },
   configs: {
     recommended: {
@@ -44,7 +45,8 @@ module.exports = {
         'jasmine/new-line-between-declarations': 1,
         'jasmine/new-line-before-expect': 1,
         'jasmine/prefer-jasmine-matcher': 1,
-        'jasmine/prefer-toHaveBeenCalledWith': 1
+        'jasmine/prefer-toHaveBeenCalledWith': 1,
+        'jasmine/prefer-spec-callback-done': 0
       }
     }
   }

--- a/lib/rules/prefer-spec-callback-done.js
+++ b/lib/rules/prefer-spec-callback-done.js
@@ -1,0 +1,78 @@
+'use strict'
+
+/**
+ * @fileoverview For specs that take a callback, prefer the callback be named `done`
+ * @author Elliot Nelson
+ */
+
+module.exports = {
+  meta: {
+    schema: [],
+    fixable: 'code'
+  },
+  create: function (context) {
+    // If we encounter an incorrectly named spec callback, rather than explore the tree
+    // ourselves to find all references to the callback, it's easier to let eslint do
+    // it for us.
+    //
+    // Keep a stack so we know whether or not we're currently looking for incorrectly
+    // named references as we encounter identifiers in the AST tree.
+    const stack = []
+
+    return {
+      'CallExpression': function (node) {
+        if (node.callee.name === 'it') {
+          let spec = node.arguments[1]
+
+          if (spec && spec.params && spec.params.length > 0 && spec.params[0].name !== 'done') {
+            stack.push({
+              node: node,
+              spec: spec,
+              name: spec.params[0].name,
+              refs: [],
+              fixable: stack.length === 0
+            })
+          } else if (spec) {
+            stack.push({
+              node: node,
+              spec: spec,
+              name: undefined,
+              refs: [],
+              fixable: false
+            })
+          }
+        }
+      },
+      'CallExpression:exit': function (node) {
+        let issue = stack[stack.length - 1]
+
+        if (issue && node === issue.node) {
+          // In eslint 5.x, you can return a multi-change patch for a single
+          // error message, which would allow us to error on the overall spec
+          // but still patch all references.
+          //
+          // To maintain support for eslint 4.x, we'll report a message for
+          // each reference to the incorrectly named callback instead, even
+          // though it might mean several warnings per spec.
+          issue.refs.forEach(function (ref) {
+            context.report({
+              message: 'Use the parameter `done` for spec callbacks',
+              node: ref,
+              fix: issue.fixable ? function (fixer) {
+                return fixer.replaceText(ref, 'done')
+              } : undefined
+            })
+          })
+          stack.pop()
+        }
+      },
+      'Identifier': function (node) {
+        for (let i = 0; i < stack.length; i++) {
+          if (stack[i].name === node.name) {
+            stack[i].refs.push(node)
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/rules/prefer-spec-callback-done.js
+++ b/test/rules/prefer-spec-callback-done.js
@@ -1,0 +1,194 @@
+'use strict'
+
+var rule = require('../../lib/rules/prefer-spec-callback-done')
+var linesToCode = require('../helpers/lines_to_code')
+var RuleTester = require('eslint').RuleTester
+
+var eslintTester = new RuleTester({ parserOptions: { ecmaVersion: 6 } })
+
+eslintTester.run('prefer spec callback done', rule, {
+  valid: [
+    {
+      code: linesToCode([
+        'it("has no callback", function () {',
+        '  expect(3).toEqual(3);',
+        '});'
+      ])
+    },
+    {
+      code: linesToCode([
+        'it("has a done callback", function (done) {',
+        '  expect(3).toEqual(3);',
+        '  done();',
+        '});'
+      ])
+    },
+    {
+      code: linesToCode([
+        'it("has an arrow function", () => {',
+        '  expect(3).toEqual(3);',
+        '});'
+      ])
+    },
+    {
+      code: linesToCode([
+        'it("has an arrow function with done callback", done => {',
+        '  expect(3).toEqual(3);',
+        '  done(); ',
+        '});'
+      ])
+    }
+  ],
+  invalid: [
+    {
+      code: linesToCode([
+        'it("has a callback", function (testComplete) {',
+        '  testMethod().then(result => {',
+        '    expect(result).toBe(true);',
+        '    testComplete();',
+        '  }).catch(testComplete.fail);',
+        '});'
+      ]),
+      output: linesToCode([
+        'it("has a callback", function (done) {',
+        '  testMethod().then(result => {',
+        '    expect(result).toBe(true);',
+        '    done();',
+        '  }).catch(done.fail);',
+        '});'
+      ]),
+      errors: [
+        {
+          message: 'Use the parameter `done` for spec callbacks',
+          line: 2,
+          column: 32
+        },
+        {
+          message: 'Use the parameter `done` for spec callbacks',
+          line: 5,
+          column: 5
+        },
+        {
+          message: 'Use the parameter `done` for spec callbacks',
+          line: 6,
+          column: 12
+        }
+      ]
+    },
+    {
+      code: linesToCode([
+        'it("has an arrow function with a callback", testComplete => {',
+        '  testMethod().then(result => {',
+        '    expect(result).toBe(true);',
+        '    testComplete();',
+        '  }).catch(testComplete.fail);',
+        '});'
+      ]),
+      output: linesToCode([
+        'it("has an arrow function with a callback", done => {',
+        '  testMethod().then(result => {',
+        '    expect(result).toBe(true);',
+        '    done();',
+        '  }).catch(done.fail);',
+        '});'
+      ]),
+      errors: [
+        {
+          message: 'Use the parameter `done` for spec callbacks',
+          line: 2,
+          column: 45
+        },
+        {
+          message: 'Use the parameter `done` for spec callbacks',
+          line: 5,
+          column: 5
+        },
+        {
+          message: 'Use the parameter `done` for spec callbacks',
+          line: 6,
+          column: 12
+        }
+      ]
+    },
+    {
+      code: linesToCode([
+        'it("is a test", function (foo) {',
+        '  foo();',
+        '  it("is a broken nested test", function (bar) {',
+        '    foo();',
+        '    bar();',
+        '  });',
+        '  foo();',
+        '  bar();',
+        '  baz();',
+        '});',
+        'it("is an unrelated test", function (baz, randomUnusedArg) {',
+        '  foo();',
+        '  bar();',
+        '  baz();',
+        '});'
+      ]),
+      output: linesToCode([
+        'it("is a test", function (done) {',
+        '  done();',
+        '  it("is a broken nested test", function (bar) {',
+        '    done();',
+        '    bar();',
+        '  });',
+        '  done();',
+        '  bar();',
+        '  baz();',
+        '});',
+        'it("is an unrelated test", function (done, randomUnusedArg) {',
+        '  foo();',
+        '  bar();',
+        '  done();',
+        '});'
+      ]),
+      errors: [
+        // Note that even though we can't safely fix the `bar` parameter and its
+        // references, we can still detect that `bar()` is a badly named callback.
+        {
+          message: 'Use the parameter `done` for spec callbacks',
+          line: 2,
+          column: 27
+        },
+        {
+          message: 'Use the parameter `done` for spec callbacks',
+          line: 3,
+          column: 3
+        },
+        {
+          message: 'Use the parameter `done` for spec callbacks',
+          line: 4,
+          column: 43
+        },
+        {
+          message: 'Use the parameter `done` for spec callbacks',
+          line: 5,
+          column: 5
+        },
+        {
+          message: 'Use the parameter `done` for spec callbacks',
+          line: 6,
+          column: 5
+        },
+        {
+          message: 'Use the parameter `done` for spec callbacks',
+          line: 8,
+          column: 3
+        },
+        {
+          message: 'Use the parameter `done` for spec callbacks',
+          line: 12,
+          column: 38
+        },
+        {
+          message: 'Use the parameter `done` for spec callbacks',
+          line: 15,
+          column: 3
+        }
+      ]
+    }
+  ]
+})


### PR DESCRIPTION
### SUMMARY

This rule requires the first parameter to a unit test (if it exists) be named `done`.

I'm suggesting this is an optional rule because _most teams_ out there just don't need it (the jasmine examples and guidebooks use `done`, most developers familiar with jasmine use `done`, etc.).

However, if you've got a team where some people have had different habits or the naming of asynchronous callbacks is causing unnecessary pull request discussion, this is a potential solution -- handle the problem at linting time and not at review time.

### TESTS
- New spec file added.