### PR TITLE
feat: new rule prefer-capitalized-spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Rule                              | Recommended                        | Options
 [no-suite-dupes][]                | 1, `'block'`                       | `['block', 'branch']`
 [no-unsafe-spy][]                 | 1                                  |
 [valid-expect][]                  | `deprecated`                       |
+[prefer-capitalized-spec][]       | 1, `never`                         | `['always', 'never']`
 [prefer-jasmine-matcher][]        | 1                                  |
 [prefer-toHaveBeenCalledWith][]   | 1                                  |
 [prefer-toBeUndefined][]          | 0                                  | `['always', 'never']`
@@ -128,6 +129,7 @@ See [configuring rules][] for more information.
 [no-suite-dupes]: docs/rules/no-suite-dupes.md
 [no-unsafe-spy]: docs/rules/no-unsafe-spy.md
 [valid-expect]: docs/rules/valid-expect.md
+[prefer-capitalized-spec]: docs/rules/prefer-capitalized-spec.md
 [prefer-jasmine-matcher]: docs/rules/prefer-jasmine-matcher.md
 [prefer-toHaveBeenCalledWith]: docs/rules/prefer-toHaveBeenCalledWith.md
 [prefer-toBeUndefined]: docs/rules/prefer-toBeUndefined.md

--- a/docs/rules/prefer-capitalized-spec.md
+++ b/docs/rules/prefer-capitalized-spec.md
@@ -1,0 +1,54 @@
+# enforce or disallow capitalization of the first letter of spec names (prefer-capitalized-spec)
+
+## Rule details
+
+This rule aims to enforce a consistent style of it statements across tests, specifically by either requiring or disallowing a capitalized letter as the first word character in an it statement. The reasoning behind this rule is that the it statement is a continuation of the describe statement. Both together form a complete sentence in many test reporters. For example:
+
+```js
+describe("User name", function() {
+  it("is required.", function() {
+  });
+});
+```
+
+may be reported by a test reporter as: User name is required.
+
+By default, this rule will be disabled.
+
+## Options
+The rule has two options: "always" or "never" which determines whether the capitalization of the first word of an it statement should be required or forbidden or ignored entirely (the default).
+
+Here is an example configuration:
+
+```js
+{
+  "prefer-capitalized-it": [
+    "error",
+    "always"
+  ]
+}
+```
+
+### "always"
+Using the always option means that this rule will report any it statements which start with a lowercase letter.
+
+The following pattern is a warning:
+
+```js
+describe("", function() {
+  it("this is invalid.", function() {
+  });
+});
+```
+
+### "never"
+Using the never option means that this rule will report any it statements which start with a uppercase letter.
+
+The following pattern is a warning:
+
+```js
+describe("", function() {
+  it("This is invalid.", function() {
+  });
+});
+```

--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ module.exports = {
     'no-expect-in-setup-teardown': require('./lib/rules/no-expect-in-setup-teardown'),
     'new-line-between-declarations': require('./lib/rules/new-line-between-declarations'),
     'new-line-before-expect': require('./lib/rules/new-line-before-expect'),
+    'prefer-capitalized-spec': require('./lib/rules/prefer-capitalized-spec'),
     'prefer-jasmine-matcher': require('./lib/rules/prefer-jasmine-matcher'),
     'prefer-toHaveBeenCalledWith': require('./lib/rules/prefer-toHaveBeenCalledWith')
   },
@@ -43,6 +44,7 @@ module.exports = {
         'jasmine/no-expect-in-setup-teardown': 1,
         'jasmine/new-line-between-declarations': 1,
         'jasmine/new-line-before-expect': 1,
+        'jasmine/prefer-capitalized-spec': 0,
         'jasmine/prefer-jasmine-matcher': 1,
         'jasmine/prefer-toHaveBeenCalledWith': 1,
         'jasmine/prefer-toBeUndefined': 0

--- a/lib/rules/prefer-capitalized-spec.js
+++ b/lib/rules/prefer-capitalized-spec.js
@@ -1,0 +1,65 @@
+'use strict'
+
+/**
+  * @fileoverview Enforce the starting case of the first character of
+  * an it statement to either be lowercase or uppercase.
+  * @author rabbidkitten, Elliot Nelson
+ */
+
+function getStringLiteralNode (node) {
+  // Raw string literals and straightforward string concatenation is safe to
+  // verify and fix. Anything more complex and we may draw incorrect conclusions
+  // (and probably can't auto-fix).
+  if (node.value) {
+    return node
+  } else if (node.left) {
+    return getStringLiteralNode(node.left)
+  } else {
+    return undefined
+  }
+}
+
+module.exports = {
+  meta: {
+    schema: [
+      {
+        enum: ['always', 'never']
+      }
+    ],
+    fixable: 'code'
+  },
+  create: function (context) {
+    const always = context.options[0] !== 'never'
+
+    return {
+      CallExpression: function (node) {
+        if (node.callee.name === 'it' || node.callee.name === 'fit' || node.callee.name === 'xit') {
+          if (node.arguments.length >= 1) {
+            var valueNode = getStringLiteralNode(node.arguments[0])
+            var value = valueNode ? valueNode.value : undefined
+
+            if (value && value.length > 0) {
+              if (always && value.charAt(0).toUpperCase() !== value.charAt(0)) {
+                context.report({
+                  message: 'Spec must start with an upper case letter',
+                  node,
+                  fix: function (fixer) {
+                    return fixer.replaceTextRange([valueNode.start + 1, valueNode.start + 2], value.charAt(0).toUpperCase())
+                  }
+                })
+              } else if (!always && value.charAt(0).toLowerCase() !== value.charAt(0)) {
+                context.report({
+                  message: 'Spec must start with a lower case letter',
+                  node,
+                  fix: function (fixer) {
+                    return fixer.replaceTextRange([valueNode.start + 1, valueNode.start + 2], value.charAt(0).toLowerCase())
+                  }
+                })
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/rules/prefer-capitalized-spec.js
+++ b/test/rules/prefer-capitalized-spec.js
@@ -1,0 +1,60 @@
+'use strict'
+
+var rule = require('../../lib/rules/prefer-capitalized-spec')
+var RuleTester = require('eslint').RuleTester
+
+var eslintTester = new RuleTester()
+
+eslintTester.run('prefer-capitalized-spec', rule, {
+  valid: [
+    {
+      code: 'it("This is valid.", function() {});',
+      options: ['always']
+    },
+    {
+      code: 'it("this is valid.", function() {});',
+      options: ['never']
+    },
+    {
+      code: '[1,2,3].forEach(value, function (value) { it("I produce " + value + ".", function() {}); });',
+      options: ['always']
+    },
+    {
+      code: '[1,2,3].forEach(value, function (value) { it("i produce " + value + ".", function() {}); });',
+      options: ['never']
+    },
+    {
+      code: 'it("we cannot tell if this is safe".toUpperCase(), function() {});',
+      options: ['always']
+    },
+    {
+      code: 'it(craftCustomDescription("we cannot tell if this is safe"), function() {});',
+      options: ['always']
+    },
+    {
+      code: 'it(["is", "this", "safe?"].join(" ").replace(/is/, "Is"), function() {});',
+      options: ['always']
+    }
+  ],
+
+  invalid: [
+    {
+      code: 'it("this is invalid.", function() {});',
+      output: 'it("This is invalid.", function() {});',
+      options: ['always'],
+      errors: [{ message: 'Spec must start with an upper case letter' }]
+    },
+    {
+      code: 'it("This is invalid.", function() {});',
+      output: 'it("this is invalid.", function() {});',
+      options: ['never'],
+      errors: [{ message: 'Spec must start with a lower case letter' }]
+    },
+    {
+      code: '[1,2,3].forEach(value, function (value) { it("i produce " + value + ".", function() {}); });',
+      output: '[1,2,3].forEach(value, function (value) { it("I produce " + value + ".", function() {}); });',
+      options: ['always'],
+      errors: [{ message: 'Spec must start with an upper case letter' }]
+    }
+  ]
+})


### PR DESCRIPTION
### SUMMARY

Add rule `prefer-capitalized-spec`, to allow users to enforce or disallow specs that begin with a capitalized first letter.

### DETAILS

The idea, doc writeup, and initial code & spec for this rule were proposed in https://github.com/tlvince/eslint-plugin-jasmine/pull/162 by https://github.com/rabidkitten.  I haven't been able to contact them, so I'm following up with a cleaned up version.

Updates:

- Rename rule from `capitalized-it` to `prefer-capitalized-spec`.
- Add schema info.
- Add fixer.
- Ensure that rule ignores situations where we cannot safely verify the spec name (function calls, expressions, etc.).
- Add verification+fixer support for _basic_ string concatenation (common in test loops).




