### PR TITLE
fix: Only report focused test keyword, not the whole test

### DIFF
--- a/lib/helpers/prohibit.js
+++ b/lib/helpers/prohibit.js
@@ -13,7 +13,14 @@ module.exports = function (prohibiteds, context) {
             name: result[1]
           },
           message: 'Unexpected {{name}}.',
-          node
+          node,
+          loc: {
+            start: node.loc.start,
+            end: {
+              line: node.loc.start.line,
+              column: node.loc.start.column + node.callee.name.length
+            }
+          }
         })
       }
     }

--- a/test/rules/no-focused-tests.js
+++ b/test/rules/no-focused-tests.js
@@ -48,6 +48,20 @@ eslintTester.run('no-focused-tests', rule, {
           type: 'CallExpression'
         }
       ]
+    },
+    {
+      code: 'fit("My focused spec", function() {\n\n});',
+      errors: [
+        {
+          message: 'Unexpected fit.',
+          type: 'CallExpression',
+          line: 1,
+          column: 1,
+          // only report the word 'fit', not the whole test:
+          endLine: 1,
+          endColumn: 4
+        }
+      ]
     }
   ]
 })


### PR DESCRIPTION
## Description

Fixes issue #230.

## How has this been tested?

I added a new test and ran all of them.

## Types of changes

- [x] Test change (non-breaking change which adds additional test scenarios)
- [ ] Refactor change (non-breaking change updates coding styles)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have ran `yarn run test` and everything passes
- [x] My code follows the code style of this project
- [ ] I have updated the documentation where necessary
- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass
