### PR TITLE
Rule proposal: prefer-promise-strategies

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Rule                              | Recommended                        | Options
 [no-unsafe-spy][]                 | 1                                  |
 [valid-expect][]                  | `deprecated`                       |
 [prefer-jasmine-matcher][]        | 1                                  |
+[prefer-promise-strategies][]     | 1                                  |
 [prefer-toHaveBeenCalledWith][]   | 1                                  |
 [prefer-toBeUndefined][]          | 0                                  | `['always', 'never']`
 
@@ -131,6 +132,7 @@ See [configuring rules][] for more information.
 [no-unsafe-spy]: docs/rules/no-unsafe-spy.md
 [valid-expect]: docs/rules/valid-expect.md
 [prefer-jasmine-matcher]: docs/rules/prefer-jasmine-matcher.md
+[prefer-promise-strategies]: docs/rules/prefer-promise-strategies.md
 [prefer-toHaveBeenCalledWith]: docs/rules/prefer-toHaveBeenCalledWith.md
 [prefer-toBeUndefined]: docs/rules/prefer-toBeUndefined.md
 

--- a/docs/rules/prefer-promise-strategies.md
+++ b/docs/rules/prefer-promise-strategies.md
@@ -1,0 +1,25 @@
+# Prefer Promise Strategies
+
+This rule recommends using `resolveTo(X)` and `rejectWith(X)` instead of `returnValue(Promise.resolve(X))` and `returnValue(Promise.reject(X))`.
+
+Aside from leading to more concise code, transforming `returnValue(Promise.reject(X))` can also avoid an unwanted `UnhandledPromiseRejectionWarning`.
+
+## Rule details
+
+Examples of *incorrect* code:
+
+```js
+const spy = jasmine.createSpy();
+
+spy.withArgs(0).returnValue(Promise.resolve(123));
+spy.and.returnValue(Promise.reject(123));
+```
+
+Examples of *correct* code:
+
+```js
+const spy = jasmine.createSpy();
+
+spy.withArgs(0).resolveTo(123);
+spy.and.rejectWith(123);
+```

--- a/docs/rules/prefer-promise-strategies.md
+++ b/docs/rules/prefer-promise-strategies.md
@@ -23,3 +23,12 @@ const spy = jasmine.createSpy();
 spy.withArgs(0).resolveTo(123);
 spy.and.rejectWith(123);
 ```
+
+## Limitations
+
+To avoid false positives, this rule only considers `returnValue` calls that match the pattern `X.{and,withArgs(Y)}.returnValue(Z)`. Thus, the following *incorrect* code is *not* recognized:
+
+```js
+const strategy = jasmine.createSpy().and;
+strategy.returnValue(Promise.resolve(123));
+```

--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ module.exports = {
     'new-line-between-declarations': require('./lib/rules/new-line-between-declarations'),
     'new-line-before-expect': require('./lib/rules/new-line-before-expect'),
     'prefer-jasmine-matcher': require('./lib/rules/prefer-jasmine-matcher'),
+    'prefer-promise-strategies': require('./lib/rules/prefer-promise-strategies'),
     'prefer-toHaveBeenCalledWith': require('./lib/rules/prefer-toHaveBeenCalledWith'),
     'prefer-toBeUndefined': require('./lib/rules/prefer-toBeUndefined')
   },
@@ -47,6 +48,7 @@ module.exports = {
         'jasmine/new-line-between-declarations': 1,
         'jasmine/new-line-before-expect': 1,
         'jasmine/prefer-jasmine-matcher': 1,
+        'jasmine/prefer-promise-strategies': 1,
         'jasmine/prefer-toHaveBeenCalledWith': 1,
         'jasmine/prefer-toBeUndefined': 0
       }

--- a/lib/rules/prefer-promise-strategies.js
+++ b/lib/rules/prefer-promise-strategies.js
@@ -31,7 +31,7 @@ module.exports = {
      * @type {import("@types/eslint").Rule.NodeListener['CallExpression']}
      */
     [`${ReturnStrategyCtor} > ${SettledPromiseCtor}.arguments:first-child`] (promiseCall) {
-      const returnStrategyCall = context.getAncestors().slice(-1)[0]
+      const returnStrategyCall = promiseCall.parent
       const returnValueMethod = returnStrategyCall.callee.property
       const preferredMethod = promiseCall.callee.property.name === 'resolve'
         ? 'resolveTo' : 'rejectWith'

--- a/lib/rules/prefer-promise-strategies.js
+++ b/lib/rules/prefer-promise-strategies.js
@@ -2,7 +2,7 @@
 
 /**
  * @fileoverview Prefer resolveTo and rejectWith instead of
- * returnValue(Promise.{resolve,reject}(X)).
+ *   returnValue(Promise.{resolve,reject}(X)).
  * @author Raphael von der Grün
  */
 
@@ -17,6 +17,7 @@ const ReturnStrategyCtor = `${SpyStrategyCall}[callee.property.name=returnValue]
 const PromiseCall = 'CallExpression[callee.object.name=Promise]'
 const SettledPromiseCtor = `${PromiseCall}[callee.property.name=/resolve|reject/]`
 
+/** @type {import("@types/eslint").Rule.RuleModule} */
 module.exports = {
   meta: {
     type: 'suggestion',
@@ -24,12 +25,10 @@ module.exports = {
     schema: []
   },
 
-  /** @param {import("@types/eslint").Rule.RuleContext} context */
   create: context => ({
     /**
      * Visits SettledPromiseCtors that are passed as first argument to a ReturnStrategyCtor
-     *
-     * @param {import("@types/estree").CallExpression} promiseCall
+     * @type {import("@types/eslint").Rule.NodeListener['CallExpression']}
      */
     [`${ReturnStrategyCtor} > ${SettledPromiseCtor}.arguments:first-child`] (promiseCall) {
       const returnStrategyCall = context.getAncestors().slice(-1)[0]
@@ -40,6 +39,7 @@ module.exports = {
       context.report({
         message: `Prefer ${preferredMethod}`,
 
+        // Highlight only the returnValue(…) part, not the entire call
         loc: {
           start: returnValueMethod.loc.start,
           end: returnStrategyCall.loc.end

--- a/lib/rules/prefer-promise-strategies.js
+++ b/lib/rules/prefer-promise-strategies.js
@@ -46,13 +46,14 @@ module.exports = {
         },
 
         fix (fixer) {
-          const promiseVal = promiseCall.arguments[0]
-          const promiseValText = promiseVal
-            ? context.getSourceCode().getText(promiseVal)
-            : ''
-
+          const code = context.getSourceCode()
           return [
-            fixer.replaceText(promiseCall, promiseValText),
+            // Replace Promise constructor call with its arguments
+            fixer.remove(promiseCall.callee),
+            fixer.remove(code.getTokenAfter(promiseCall.callee)),
+            fixer.remove(code.getLastToken(promiseCall)),
+
+            // Replace returnValue method with resolveTo or rejectWith
             fixer.replaceText(returnValueMethod, preferredMethod)
           ]
         }

--- a/lib/rules/prefer-promise-strategies.js
+++ b/lib/rules/prefer-promise-strategies.js
@@ -1,0 +1,62 @@
+'use strict'
+
+/**
+ * @fileoverview Prefer resolveTo and rejectWith instead of
+ * returnValue(Promise.{resolve,reject}(X)).
+ * @author Raphael von der Grün
+ */
+
+// Matches X.{and,withArgs(Y)}.returnValue(Z)
+const SpyStrategyCall = `CallExpression:matches(
+  [callee.object.property.name=and],
+  [callee.object.callee.property.name=withArgs]
+)`.replace(/\s+/g, ' ')
+const ReturnStrategyCtor = `${SpyStrategyCall}[callee.property.name=returnValue]`
+
+// Matches Promise.{resolve,reject}(X)
+const PromiseCall = 'CallExpression[callee.object.name=Promise]'
+const SettledPromiseCtor = `${PromiseCall}[callee.property.name=/resolve|reject/]`
+
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    fixable: 'code',
+    schema: []
+  },
+
+  /** @param {import("@types/eslint").Rule.RuleContext} context */
+  create: context => ({
+    /**
+     * Visits SettledPromiseCtors that are passed as first argument to a ReturnStrategyCtor
+     *
+     * @param {import("@types/estree").CallExpression} promiseCall
+     */
+    [`${ReturnStrategyCtor} > ${SettledPromiseCtor}.arguments:first-child`] (promiseCall) {
+      const returnStrategyCall = context.getAncestors().slice(-1)[0]
+      const returnValueMethod = returnStrategyCall.callee.property
+      const preferredMethod = promiseCall.callee.property.name === 'resolve'
+        ? 'resolveTo' : 'rejectWith'
+
+      context.report({
+        message: `Prefer ${preferredMethod}`,
+
+        loc: {
+          start: returnValueMethod.loc.start,
+          end: returnStrategyCall.loc.end
+        },
+
+        fix (fixer) {
+          const promiseVal = promiseCall.arguments[0]
+          const promiseValText = promiseVal
+            ? context.getSourceCode().getText(promiseVal)
+            : ''
+
+          return [
+            fixer.replaceText(promiseCall, promiseValText),
+            fixer.replaceText(returnValueMethod, preferredMethod)
+          ]
+        }
+      })
+    }
+  })
+}

--- a/test/rules/prefer-promise-strategies.js
+++ b/test/rules/prefer-promise-strategies.js
@@ -33,6 +33,13 @@ eslintTester.run('prefer-promise-strategies', rule, {
       errors: [
         { message: 'Prefer rejectWith' }
       ]
+    },
+    { // Handles empty argument list
+      code: 'spy.and.returnValue(Promise.resolve());',
+      output: 'spy.and.resolveTo();',
+      errors: [
+        { message: 'Prefer resolveTo' }
+      ]
     }
   ]
 })

--- a/test/rules/prefer-promise-strategies.js
+++ b/test/rules/prefer-promise-strategies.js
@@ -40,6 +40,13 @@ eslintTester.run('prefer-promise-strategies', rule, {
       errors: [
         { message: 'Prefer resolveTo' }
       ]
+    },
+    { // Handles multiple arguments (even if invalid)
+      code: 'spy.and.returnValue(Promise.resolve(1,2, 3));',
+      output: 'spy.and.resolveTo(1,2, 3);',
+      errors: [
+        { message: 'Prefer resolveTo' }
+      ]
     }
   ]
 })

--- a/test/rules/prefer-promise-strategies.js
+++ b/test/rules/prefer-promise-strategies.js
@@ -1,0 +1,38 @@
+'use strict'
+
+const rule = require('../../lib/rules/prefer-promise-strategies')
+const { RuleTester } = require('eslint')
+
+const parserOptions = { ecmaVersion: 6 }
+const eslintTester = new RuleTester({ parserOptions })
+
+eslintTester.run('prefer-promise-strategies', rule, {
+  valid: [
+    { code: 'spy.and.returnValue(Promise.foo());' },
+    { code: 'spy.and.returnValue();' },
+    { code: 'spy.and.returnValue(123);' },
+    { code: 'spy.and.returnValue(foo());' },
+    { code: 'obj.returnValue(Promise.reject());' },
+    { code: 'spy.and.returnValue(fn => fn(Promise.resolve(123)));' },
+    {
+      // Should be invalid but would need more complex analysis
+      code: 'const s = spy.and; s.returnValue(Promise.reject(123));'
+    }
+  ],
+  invalid: [
+    {
+      code: 'spy.withArgs(0).returnValue(Promise.resolve(123));',
+      output: 'spy.withArgs(0).resolveTo(123);',
+      errors: [
+        { message: 'Prefer resolveTo' }
+      ]
+    },
+    {
+      code: 'spy.and.returnValue(Promise.reject(123));',
+      output: 'spy.and.rejectWith(123);',
+      errors: [
+        { message: 'Prefer rejectWith' }
+      ]
+    }
+  ]
+})

--- a/test/rules/prefer-promise-strategies.js
+++ b/test/rules/prefer-promise-strategies.js
@@ -16,7 +16,7 @@ eslintTester.run('prefer-promise-strategies', rule, {
     { code: 'spy.and.returnValue(fn => fn(Promise.resolve(123)));' },
     {
       // Should be invalid but would need more complex analysis
-      code: 'const s = spy.and; s.returnValue(Promise.reject(123));'
+      code: 'const s = spy.and; s.returnValue(Promise.resolve(123));'
     }
   ],
   invalid: [


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->
This adds a new rule to enforce the use of the new `resolveTo` and `rejectWith` strategies instead of the more verbose alternative of using the `returnValue` strategy.

### Bad Code Example
```js
spy.withArgs(0).returnValue(Promise.resolve(123));
spy.and.returnValue(Promise.reject(123));
```

### Good Code Example
```js
spy.withArgs(0).resolveTo(123);
spy.and.rejectWith(123);
```

The rule also includes a fixer that will transform above bad into the good example.

### Motivation
Aside from leading to more concise code, transforming the `returnValue(Promise.reject())` example can also avoid an unwanted UnhandledPromiseRejectionWarning.

## How has this been tested?
I have added tests to cover my changes

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Test change (non-breaking change which adds additional test scenarios)
- [ ] Refactor change (non-breaking change updates coding styles)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have ran `npm run test` and everything passes
- [x] My code follows the code style of this project
- [x] I have updated the documentation where necessary
- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass
