### PR TITLE
fix(rule): Support await/return expect() for new-line-before-expect rule

### DIFF
--- a/docs/rules/new-line-before-expect.md
+++ b/docs/rules/new-line-before-expect.md
@@ -51,6 +51,26 @@ describe("", function() {
 
 ```js
 describe("", function() {
+  it("", async function() {
+    var a = 1;
+
+    await expect(a).toBe(1);
+  });
+});
+```
+
+```js
+describe("", function() {
+  it("", function() {
+    var a = 1;
+
+    return expect(a).toBe(1);
+  });
+});
+```
+
+```js
+describe("", function() {
   it("", function() {
     var a = 1;
 

--- a/lib/rules/new-line-before-expect.js
+++ b/lib/rules/new-line-before-expect.js
@@ -26,7 +26,11 @@ module.exports = function (context) {
         }
         lastExpectNode = node
         var sourceCode = context.getSourceCode()
-        const prevToken = sourceCode.getTokenBefore(node)
+        let prevToken = sourceCode.getTokenBefore(node)
+        if (prevToken.value === 'await' || prevToken.value === 'return') {
+          node = prevToken
+          prevToken = sourceCode.getTokenBefore(prevToken)
+        }
         if (prevToken) {
           if (prevToken.type === 'Punctuator' && prevToken.value === '{') {
             return

--- a/test/rules/new-line-before-expect.js
+++ b/test/rules/new-line-before-expect.js
@@ -3,8 +3,10 @@
 var rule = require('../../lib/rules/new-line-before-expect')
 var linesToCode = require('../helpers/lines_to_code')
 var RuleTester = require('eslint').RuleTester
-
-var eslintTester = new RuleTester()
+const parserOptions = {
+  ecmaVersion: 8
+}
+var eslintTester = new RuleTester({ parserOptions })
 
 eslintTester.run('new line before expect', rule, {
   valid: [
@@ -41,6 +43,15 @@ eslintTester.run('new line before expect', rule, {
       '});'
     ]),
     linesToCode([
+      'describe("", function() {',
+      ' it("", async function(){',
+      '  var a = 1',
+      '',
+      '  await expect(a).toBe(1)',
+      ' });',
+      '});'
+    ]),
+    linesToCode([
       'it("", helper(function() {',
       '  var a = 1',
       '',
@@ -69,6 +80,11 @@ eslintTester.run('new line before expect', rule, {
       ' ',
       '  expect(1).toEqual(1);',
       '}));'
+    ]),
+    linesToCode([
+      'it("", function() {',
+      '  return expect(1).toEqual(1);',
+      '});'
     ])
 
   ],
@@ -114,6 +130,46 @@ eslintTester.run('new line before expect', rule, {
         '  var a = 1',
         '',
         '  expect(a).toEqual(1);',
+        '}));'
+      ])
+    },
+    {
+      code: linesToCode([
+        'it("", helper(async function() {',
+        '  var a = 1',
+        '  await expect(a).toEqual(1);',
+        '}));'
+      ]),
+      errors: [
+        {
+          message: 'No new line before expect'
+        }
+      ],
+      output: linesToCode([
+        'it("", helper(async function() {',
+        '  var a = 1',
+        '',
+        '  await expect(a).toEqual(1);',
+        '}));'
+      ])
+    },
+    {
+      code: linesToCode([
+        'it("", helper(function() {',
+        '  var a = 1',
+        '  return expect(a).toEqual(1);',
+        '}));'
+      ]),
+      errors: [
+        {
+          message: 'No new line before expect'
+        }
+      ],
+      output: linesToCode([
+        'it("", helper(function() {',
+        '  var a = 1',
+        '',
+        '  return expect(a).toEqual(1);',
         '}));'
       ])
     },


### PR DESCRIPTION
## Description

This PR fixes #161. The issue is that the `new-line-before-expect` rule wasn't able to handle `await expect()` and `return expect()` properly. This is a common pattern with [jest for example](https://jestjs.io/docs/en/asynchronous#asyncawait).

## How has this been tested?

I added additional unit tests for `await expect()` and `return expect()` cases.

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Test change (non-breaking change which adds additional test scenarios)
- [ ] Refactor change (non-breaking change updates coding styles)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have ran `npm run test` and everything passes
- [x] My code follows the code style of this project
- [x] I have updated the documentation where necessary
- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass
