### PR TITLE
feat(missing-expect): Add suport for regular expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Rule                              | Recommended                        | Options
 ----                              | -----------                        | -------
 [expect-matcher][]                | 1,                                 |
 [expect-single-argument][]        | 1,                                 |
-[missing-expect][]                | 0, `'expect()'`, `'expectAsync()'` | expectation function names
+[missing-expect][]                | 0, `'expect()'`, `'expectAsync()'` | expectation function names or regex
 [named-spy][]                     | 0                                  |
 [new-line-before-expect][]        | 1                                  |
 [new-line-between-declarations][] | 1                                  |

--- a/docs/rules/missing-expect.md
+++ b/docs/rules/missing-expect.md
@@ -7,7 +7,7 @@ A test which doesn't make any expectations doesn't really test anything.
 This rule triggers a warning if no expectations are made. This rule is disabled
 by default.
 
-An array of expect function names may be passed to the configuration of this
+An array of expect function names or regexes may be passed to the configuration of this
 rule. By default only `expect` is used.
 
 ### Default configuration

--- a/lib/rules/missing-expect.js
+++ b/lib/rules/missing-expect.js
@@ -8,7 +8,7 @@
 var buildName = require('../helpers/buildName')
 
 module.exports = function (context) {
-  var allowed = context.options.length ? context.options : ['expect()', 'expectAsync()']
+  var allowed = context.options.length ? context.options.map((allowedExpression) => new RegExp(allowedExpression.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))) : [/^expect()/, /^expectAsync()/]
 
   var unchecked = []
 
@@ -20,7 +20,8 @@ module.exports = function (context) {
         }
         return
       }
-      if (allowed.indexOf(buildName(node)) === -1) {
+      var builtName = buildName(node)
+      if (!allowed.some((regexp) => regexp.test(builtName))) {
         return
       }
       context.getAncestors().some(function (ancestor) {

--- a/test/rules/missing-expect.js
+++ b/test/rules/missing-expect.js
@@ -36,6 +36,18 @@ eslintTester.run('missing-expect', rule, {
       options: [
         'a.deeply.nested().expect.expression()'
       ]
+    },
+    {
+      code: 'it("", function() {sinon.verify()})',
+      options: [
+        '.verify()'
+      ]
+    },
+    {
+      code: 'it("", function() {some.object.with.expectation.at.the.end()})',
+      options: [
+        'some.object'
+      ]
     }
   ],
 
@@ -82,6 +94,22 @@ eslintTester.run('missing-expect', rule, {
     },
     {
       code: 'it("", function() {var foo = bar();})',
+      errors: [
+        {
+          message: 'Test has no expectations'
+        }
+      ]
+    },
+    {
+      code: 'it("", function() {var expectedResult = ""})',
+      errors: [
+        {
+          message: 'Test has no expectations'
+        }
+      ]
+    },
+    {
+      code: 'it("", function() {functionwithexpect()})',
       errors: [
         {
           message: 'Test has no expectations'


### PR DESCRIPTION
## Description

Some libraries provide verification and expectations functions that are
properties to an object. The notable example being `sinon`
(https://sinonjs.org/), which provides methods like `.verify()` on mocks.
This commit adds support for regular expressions as acceptable parameters to the
`missing-expect` rule so these can be considered valid expectations.

## How has this been tested?

- Added two new passing test cases for this rule that leverage regular
  expressions as acceptable methods.
- Added two new failing test cases for code that includes `expect` in some form,
  to verify these are not considered valid expectations.

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Test change (non-breaking change which adds additional test scenarios)
- [ ] Refactor change (non-breaking change updates coding styles)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have ran `npm run test` and everything passes
- [x] My code follows the code style of this project
- [x] I have updated the documentation where necessary
- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass
