### PR TITLE
fix(no-describe-variables): Check variable declarations in arrow functions

### DIFF
--- a/lib/rules/no-describe-variables.js
+++ b/lib/rules/no-describe-variables.js
@@ -16,6 +16,9 @@ module.exports = function (context) {
   return {
     'CallExpression[callee.name="describe"] > FunctionExpression > BlockStatement > VariableDeclaration': report.bind(this, context),
     'CallExpression[callee.name="xdescribe"] > FunctionExpression > BlockStatement > VariableDeclaration': report.bind(this, context),
-    'CallExpression[callee.name="fdescribe"] > FunctionExpression > BlockStatement > VariableDeclaration': report.bind(this, context)
+    'CallExpression[callee.name="fdescribe"] > FunctionExpression > BlockStatement > VariableDeclaration': report.bind(this, context),
+    'CallExpression[callee.name="describe"] > ArrowFunctionExpression > BlockStatement > VariableDeclaration': report.bind(this, context),
+    'CallExpression[callee.name="fdescribe"] > ArrowFunctionExpression > BlockStatement > VariableDeclaration': report.bind(this, context),
+    'CallExpression[callee.name="xdescribe"] > ArrowFunctionExpression > BlockStatement > VariableDeclaration': report.bind(this, context)
   }
 }

--- a/test/rules/no-describe-variables.js
+++ b/test/rules/no-describe-variables.js
@@ -3,7 +3,11 @@
 var rule = require('../../lib/rules/no-describe-variables')
 var RuleTester = require('eslint').RuleTester
 
-var eslintTester = new RuleTester()
+var eslintTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 6
+  }
+})
 
 eslintTester.run('no-describe-variables', rule, {
   valid: [
@@ -30,6 +34,30 @@ eslintTester.run('no-describe-variables', rule, {
     },
     {
       code: 'xdescribe("My suite", function() { var x; beforeEach(function () { x = 5; }); it("works", function() {}); });',
+      errors: [
+        {
+          message: 'Test has variable declaration in the describe block'
+        }
+      ]
+    },
+    {
+      code: 'describe("My suite", () => { var x; beforeEach(() => { x = 5; }); it("works", () => {}); });',
+      errors: [
+        {
+          message: 'Test has variable declaration in the describe block'
+        }
+      ]
+    },
+    {
+      code: 'fdescribe("My suite", () => { var x; beforeEach(() => { x = 5; }); it("works", () => {}); });',
+      errors: [
+        {
+          message: 'Test has variable declaration in the describe block'
+        }
+      ]
+    },
+    {
+      code: 'xdescribe("My suite", () => { var x; beforeEach(() => { x = 5; }); it("works", () => {}); });',
       errors: [
         {
           message: 'Test has variable declaration in the describe block'


### PR DESCRIPTION

## Description

This fixes the issue #233 for arrow function definitions in describe

## How has this been tested?

I wrote unit tests in Mocha for the new rules

## Types of changes

- [ ] Test change (non-breaking change which adds additional test scenarios)
- [ ] Refactor change (non-breaking change updates coding styles)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist


- [x] I have ran `npm run test` and everything passes
- [x] My code follows the code style of this project
- [x] I have updated the documentation where necessary
- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass
