### PR TITLE
Implement rules for preferences for true/false/null

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ Rule                              | Recommended                        | Options
 [prefer-promise-strategies][]     | 1                                  |
 [prefer-toHaveBeenCalledWith][]   | 1                                  |
 [prefer-toBeUndefined][]          | 0                                  | `['always', 'never']`
+[prefer-toBeNull][]               | 0                                  | `['always', 'never']`
+[prefer-toBeTrue][]               | 0                                  | `['always', 'never']`
+[prefer-toBeFalse][]              | 0                                  | `['always', 'never']`
 
 
 For example, using the recommended configuration, the `no-focused-tests` rule
@@ -135,6 +138,9 @@ See [configuring rules][] for more information.
 [prefer-promise-strategies]: docs/rules/prefer-promise-strategies.md
 [prefer-toHaveBeenCalledWith]: docs/rules/prefer-toHaveBeenCalledWith.md
 [prefer-toBeUndefined]: docs/rules/prefer-toBeUndefined.md
+[prefer-toBeNull]: docs/rules/prefer-toBeNull.md
+[prefer-toBeTrue]: docs/rules/prefer-toBeTrue.md
+[prefer-toBeFalse]: docs/rules/prefer-toBeFalse.md
 
 [configuring rules]: http://eslint.org/docs/user-guide/configuring#configuring-rules
 

--- a/docs/rules/prefer-toBeFalse.md
+++ b/docs/rules/prefer-toBeFalse.md
@@ -1,0 +1,51 @@
+# Prefer toBeFalse
+
+This rule recommends using `toBeFalse` instead of the more generic matcher
+`toBe(false)`.
+
+## Rule details
+
+This rule forces a codebase to be consistent when expecting values to be
+`false` in unit tests.
+
+## Options
+
+### always
+
+The `"always"` option (default) prefers `toBeFalse()`. Select this option
+if you'd like developers to use a matcher that tests specifically for
+`false`.
+
+Examples of *incorrect* code for the `"always"` option:
+
+```js
+expect(value).toBe(false);
+expect(value).toBe(false, 'with an explanation');
+```
+
+Examples of *correct* code for the `"always"` option:
+
+```js
+expect(value).toBeFalse();
+expect(value).toBeFalse('with an explanation');
+```
+
+### never
+
+The `"never"` option prefers `toBe(false)`. Select this option if you'd
+like developers to use the `toBe` matcher consistently, whether testing
+for `false` or not.
+
+Examples of *incorrect* code for the `"never"` option:
+
+```js
+expect(value).toBeFalse();
+expect(value).toBeFalse('with an explanation');
+```
+
+Examples of *correct* code for the `"never"` option:
+
+```js
+expect(value).toBe(false);
+expect(value).toBe(false, 'with an explanation');
+```

--- a/docs/rules/prefer-toBeNull.md
+++ b/docs/rules/prefer-toBeNull.md
@@ -1,0 +1,51 @@
+# Prefer toBeNull
+
+This rule recommends using `toBeNull` instead of the more generic matcher
+`toBe(null)`.
+
+## Rule details
+
+This rule forces a codebase to be consistent when expecting values to be
+`null` in unit tests.
+
+## Options
+
+### always
+
+The `"always"` option (default) prefers `toBeNull()`. Select this option
+if you'd like developers to use a matcher that tests specifically for
+`null`.
+
+Examples of *incorrect* code for the `"always"` option:
+
+```js
+expect(value).toBe(null);
+expect(value).toBe(null, 'with an explanation');
+```
+
+Examples of *correct* code for the `"always"` option:
+
+```js
+expect(value).toBeNull();
+expect(value).toBeNull('with an explanation');
+```
+
+### never
+
+The `"never"` option prefers `toBe(null)`. Select this option if you'd
+like developers to use the `toBe` matcher consistently, whether testing
+for `null` or not.
+
+Examples of *incorrect* code for the `"never"` option:
+
+```js
+expect(value).toBeNull();
+expect(value).toBeNull('with an explanation');
+```
+
+Examples of *correct* code for the `"never"` option:
+
+```js
+expect(value).toBe(null);
+expect(value).toBe(null, 'with an explanation');
+```

--- a/docs/rules/prefer-toBeTrue.md
+++ b/docs/rules/prefer-toBeTrue.md
@@ -1,0 +1,51 @@
+# Prefer toBeTrue
+
+This rule recommends using `toBeTrue` instead of the more generic matcher
+`toBe(true)`.
+
+## Rule details
+
+This rule forces a codebase to be consistent when expecting values to be
+`true` in unit tests.
+
+## Options
+
+### always
+
+The `"always"` option (default) prefers `toBeTrue()`. Select this option
+if you'd like developers to use a matcher that tests specifically for
+`true`.
+
+Examples of *incorrect* code for the `"always"` option:
+
+```js
+expect(value).toBe(true);
+expect(value).toBe(true, 'with an explanation');
+```
+
+Examples of *correct* code for the `"always"` option:
+
+```js
+expect(value).toBeTrue();
+expect(value).toBeTrue('with an explanation');
+```
+
+### never
+
+The `"never"` option prefers `toBe(true)`. Select this option if you'd
+like developers to use the `toBe` matcher consistently, whether testing
+for `true` or not.
+
+Examples of *incorrect* code for the `"never"` option:
+
+```js
+expect(value).toBeTrue();
+expect(value).toBeTrue('with an explanation');
+```
+
+Examples of *correct* code for the `"never"` option:
+
+```js
+expect(value).toBe(true);
+expect(value).toBe(true, 'with an explanation');
+```

--- a/index.js
+++ b/index.js
@@ -24,7 +24,10 @@ module.exports = {
     'prefer-jasmine-matcher': require('./lib/rules/prefer-jasmine-matcher'),
     'prefer-promise-strategies': require('./lib/rules/prefer-promise-strategies'),
     'prefer-toHaveBeenCalledWith': require('./lib/rules/prefer-toHaveBeenCalledWith'),
-    'prefer-toBeUndefined': require('./lib/rules/prefer-toBeUndefined')
+    'prefer-toBeUndefined': require('./lib/rules/prefer-toBeUndefined'),
+    'prefer-toBeNull': require('./lib/rules/prefer-toBeNull'),
+    'prefer-toBeTrue': require('./lib/rules/prefer-toBeTrue'),
+    'prefer-toBeFalse': require('./lib/rules/prefer-toBeFalse')
   },
   configs: {
     recommended: {

--- a/lib/rules/prefer-toBeFalse.js
+++ b/lib/rules/prefer-toBeFalse.js
@@ -1,0 +1,55 @@
+'use strict'
+
+/**
+ * @fileoverview Prefer toBeTrue instead of toBe(true)
+ * @author Osama Yousry
+ */
+
+module.exports = {
+  meta: {
+    schema: [
+      {
+        enum: ['always', 'never']
+      }
+    ],
+    fixable: 'code'
+  },
+  create: function (context) {
+    const always = context.options[0] !== 'never'
+
+    return {
+      CallExpression: function (node) {
+        if (always) {
+          if (node.callee.type === 'MemberExpression' && node.callee.property.name === 'toBe' &&
+              node.arguments[0] && node.arguments[0].type === 'Literal' && node.arguments[0].value === false) {
+            context.report({
+              message: 'Prefer toBeFalse() to expect false',
+              node: node.callee.property,
+              fix: function (fixer) {
+                if (node.arguments.length === 1) {
+                  return fixer.replaceTextRange([node.callee.property.start, node.arguments[0].end], 'toBeFalse(')
+                } else {
+                  return fixer.replaceTextRange([node.callee.property.start, node.arguments[1].start], 'toBeFalse(')
+                }
+              }
+            })
+          }
+        } else {
+          if (node.callee.type === 'MemberExpression' && node.callee.property.name === 'toBeFalse') {
+            context.report({
+              message: 'Prefer toBe(false) to expect false',
+              node: node.callee.property,
+              fix: function (fixer) {
+                if (node.arguments.length === 0) {
+                  return fixer.replaceTextRange([node.callee.property.start, node.end], 'toBe(false)')
+                } else {
+                  return fixer.replaceTextRange([node.callee.property.start, node.arguments[0].start], 'toBe(false, ')
+                }
+              }
+            })
+          }
+        }
+      }
+    }
+  }
+}

--- a/lib/rules/prefer-toBeNull.js
+++ b/lib/rules/prefer-toBeNull.js
@@ -1,0 +1,55 @@
+'use strict'
+
+/**
+ * @fileoverview Prefer toBeNull instead of toBe(null)
+ * @author Osama Yousry
+ */
+
+module.exports = {
+  meta: {
+    schema: [
+      {
+        enum: ['always', 'never']
+      }
+    ],
+    fixable: 'code'
+  },
+  create: function (context) {
+    const always = context.options[0] !== 'never'
+
+    return {
+      CallExpression: function (node) {
+        if (always) {
+          if (node.callee.type === 'MemberExpression' && node.callee.property.name === 'toBe' &&
+              node.arguments[0] && node.arguments[0].type === 'Literal' && node.arguments[0].value === null) {
+            context.report({
+              message: 'Prefer toBeNull() to expect null',
+              node: node.callee.property,
+              fix: function (fixer) {
+                if (node.arguments.length === 1) {
+                  return fixer.replaceTextRange([node.callee.property.start, node.arguments[0].end], 'toBeNull(')
+                } else {
+                  return fixer.replaceTextRange([node.callee.property.start, node.arguments[1].start], 'toBeNull(')
+                }
+              }
+            })
+          }
+        } else {
+          if (node.callee.type === 'MemberExpression' && node.callee.property.name === 'toBeNull') {
+            context.report({
+              message: 'Prefer toBe(null) to expect null',
+              node: node.callee.property,
+              fix: function (fixer) {
+                if (node.arguments.length === 0) {
+                  return fixer.replaceTextRange([node.callee.property.start, node.end], 'toBe(null)')
+                } else {
+                  return fixer.replaceTextRange([node.callee.property.start, node.arguments[0].start], 'toBe(null, ')
+                }
+              }
+            })
+          }
+        }
+      }
+    }
+  }
+}

--- a/lib/rules/prefer-toBeTrue.js
+++ b/lib/rules/prefer-toBeTrue.js
@@ -1,0 +1,55 @@
+'use strict'
+
+/**
+ * @fileoverview Prefer toBeTrue instead of toBe(true)
+ * @author Osama Yousry
+ */
+
+module.exports = {
+  meta: {
+    schema: [
+      {
+        enum: ['always', 'never']
+      }
+    ],
+    fixable: 'code'
+  },
+  create: function (context) {
+    const always = context.options[0] !== 'never'
+
+    return {
+      CallExpression: function (node) {
+        if (always) {
+          if (node.callee.type === 'MemberExpression' && node.callee.property.name === 'toBe' &&
+              node.arguments[0] && node.arguments[0].type === 'Literal' && node.arguments[0].value === true) {
+            context.report({
+              message: 'Prefer toBeTrue() to expect true',
+              node: node.callee.property,
+              fix: function (fixer) {
+                if (node.arguments.length === 1) {
+                  return fixer.replaceTextRange([node.callee.property.start, node.arguments[0].end], 'toBeTrue(')
+                } else {
+                  return fixer.replaceTextRange([node.callee.property.start, node.arguments[1].start], 'toBeTrue(')
+                }
+              }
+            })
+          }
+        } else {
+          if (node.callee.type === 'MemberExpression' && node.callee.property.name === 'toBeTrue') {
+            context.report({
+              message: 'Prefer toBe(true) to expect true',
+              node: node.callee.property,
+              fix: function (fixer) {
+                if (node.arguments.length === 0) {
+                  return fixer.replaceTextRange([node.callee.property.start, node.end], 'toBe(true)')
+                } else {
+                  return fixer.replaceTextRange([node.callee.property.start, node.arguments[0].start], 'toBe(true, ')
+                }
+              }
+            })
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/rules/prefer-toBeFalse.js
+++ b/test/rules/prefer-toBeFalse.js
@@ -1,0 +1,107 @@
+'use strict'
+
+var rule = require('../../lib/rules/prefer-toBeFalse')
+var linesToCode = require('../helpers/lines_to_code')
+var RuleTester = require('eslint').RuleTester
+
+var eslintTester = new RuleTester()
+
+eslintTester.run('prefer toBeFalse', rule, {
+  valid: [
+    {
+      code: linesToCode([
+        'expect(x).toBeFalse();'
+      ])
+    },
+    {
+      code: linesToCode([
+        'expect(x).toBeFalse("with an optional message");'
+      ])
+    },
+    {
+      options: ['never'],
+      code: linesToCode([
+        'expect(x).toBe(false);'
+      ])
+    },
+    {
+      options: ['never'],
+      code: linesToCode([
+        'expect(x).toBe(false, "with an optional message");'
+      ])
+    }
+  ],
+  invalid: [
+    {
+      code: linesToCode([
+        'expect(x).toBe(false);'
+      ]),
+      output: linesToCode([
+        'expect(x).toBeFalse();'
+      ]),
+      errors: [
+        {
+          message: 'Prefer toBeFalse() to expect false'
+        }
+      ]
+    },
+    {
+      code: linesToCode([
+        'expect(x).toBe(false, "with an optional message", "???");'
+      ]),
+      output: linesToCode([
+        'expect(x).toBeFalse("with an optional message", "???");'
+      ]),
+      errors: [
+        {
+          message: 'Prefer toBeFalse() to expect false'
+        }
+      ]
+    },
+    {
+      code: linesToCode([
+        'expect(x).toBe(',
+        '  false,',
+        '  "why would you do this?"',
+        ');'
+      ]),
+      output: linesToCode([
+        'expect(x).toBeFalse("why would you do this?"',
+        ');'
+      ]),
+      errors: [
+        {
+          message: 'Prefer toBeFalse() to expect false'
+        }
+      ]
+    },
+    {
+      options: ['never'],
+      code: linesToCode([
+        'expect(x).toBeFalse();'
+      ]),
+      output: linesToCode([
+        'expect(x).toBe(false);'
+      ]),
+      errors: [
+        {
+          message: 'Prefer toBe(false) to expect false'
+        }
+      ]
+    },
+    {
+      options: ['never'],
+      code: linesToCode([
+        'expect(x).toBeFalse("with optional args", "???");'
+      ]),
+      output: linesToCode([
+        'expect(x).toBe(false, "with optional args", "???");'
+      ]),
+      errors: [
+        {
+          message: 'Prefer toBe(false) to expect false'
+        }
+      ]
+    }
+  ]
+})

--- a/test/rules/prefer-toBeNull.js
+++ b/test/rules/prefer-toBeNull.js
@@ -1,0 +1,107 @@
+'use strict'
+
+var rule = require('../../lib/rules/prefer-toBeNull')
+var linesToCode = require('../helpers/lines_to_code')
+var RuleTester = require('eslint').RuleTester
+
+var eslintTester = new RuleTester()
+
+eslintTester.run('prefer toBeNull', rule, {
+  valid: [
+    {
+      code: linesToCode([
+        'expect(x).toBeNull();'
+      ])
+    },
+    {
+      code: linesToCode([
+        'expect(x).toBeNull("with an optional message");'
+      ])
+    },
+    {
+      options: ['never'],
+      code: linesToCode([
+        'expect(x).toBe(null);'
+      ])
+    },
+    {
+      options: ['never'],
+      code: linesToCode([
+        'expect(x).toBe(null, "with an optional message");'
+      ])
+    }
+  ],
+  invalid: [
+    {
+      code: linesToCode([
+        'expect(x).toBe(null);'
+      ]),
+      output: linesToCode([
+        'expect(x).toBeNull();'
+      ]),
+      errors: [
+        {
+          message: 'Prefer toBeNull() to expect null'
+        }
+      ]
+    },
+    {
+      code: linesToCode([
+        'expect(x).toBe(null, "with an optional message", "???");'
+      ]),
+      output: linesToCode([
+        'expect(x).toBeNull("with an optional message", "???");'
+      ]),
+      errors: [
+        {
+          message: 'Prefer toBeNull() to expect null'
+        }
+      ]
+    },
+    {
+      code: linesToCode([
+        'expect(x).toBe(',
+        '  null,',
+        '  "why would you do this?"',
+        ');'
+      ]),
+      output: linesToCode([
+        'expect(x).toBeNull("why would you do this?"',
+        ');'
+      ]),
+      errors: [
+        {
+          message: 'Prefer toBeNull() to expect null'
+        }
+      ]
+    },
+    {
+      options: ['never'],
+      code: linesToCode([
+        'expect(x).toBeNull();'
+      ]),
+      output: linesToCode([
+        'expect(x).toBe(null);'
+      ]),
+      errors: [
+        {
+          message: 'Prefer toBe(null) to expect null'
+        }
+      ]
+    },
+    {
+      options: ['never'],
+      code: linesToCode([
+        'expect(x).toBeNull("with optional args", "???");'
+      ]),
+      output: linesToCode([
+        'expect(x).toBe(null, "with optional args", "???");'
+      ]),
+      errors: [
+        {
+          message: 'Prefer toBe(null) to expect null'
+        }
+      ]
+    }
+  ]
+})

--- a/test/rules/prefer-toBeTrue.js
+++ b/test/rules/prefer-toBeTrue.js
@@ -1,0 +1,107 @@
+'use strict'
+
+var rule = require('../../lib/rules/prefer-toBeTrue')
+var linesToCode = require('../helpers/lines_to_code')
+var RuleTester = require('eslint').RuleTester
+
+var eslintTester = new RuleTester()
+
+eslintTester.run('prefer toBeTrue', rule, {
+  valid: [
+    {
+      code: linesToCode([
+        'expect(x).toBeTrue();'
+      ])
+    },
+    {
+      code: linesToCode([
+        'expect(x).toBeTrue("with an optional message");'
+      ])
+    },
+    {
+      options: ['never'],
+      code: linesToCode([
+        'expect(x).toBe(true);'
+      ])
+    },
+    {
+      options: ['never'],
+      code: linesToCode([
+        'expect(x).toBe(true, "with an optional message");'
+      ])
+    }
+  ],
+  invalid: [
+    {
+      code: linesToCode([
+        'expect(x).toBe(true);'
+      ]),
+      output: linesToCode([
+        'expect(x).toBeTrue();'
+      ]),
+      errors: [
+        {
+          message: 'Prefer toBeTrue() to expect true'
+        }
+      ]
+    },
+    {
+      code: linesToCode([
+        'expect(x).toBe(true, "with an optional message", "???");'
+      ]),
+      output: linesToCode([
+        'expect(x).toBeTrue("with an optional message", "???");'
+      ]),
+      errors: [
+        {
+          message: 'Prefer toBeTrue() to expect true'
+        }
+      ]
+    },
+    {
+      code: linesToCode([
+        'expect(x).toBe(',
+        '  true,',
+        '  "why would you do this?"',
+        ');'
+      ]),
+      output: linesToCode([
+        'expect(x).toBeTrue("why would you do this?"',
+        ');'
+      ]),
+      errors: [
+        {
+          message: 'Prefer toBeTrue() to expect true'
+        }
+      ]
+    },
+    {
+      options: ['never'],
+      code: linesToCode([
+        'expect(x).toBeTrue();'
+      ]),
+      output: linesToCode([
+        'expect(x).toBe(true);'
+      ]),
+      errors: [
+        {
+          message: 'Prefer toBe(true) to expect true'
+        }
+      ]
+    },
+    {
+      options: ['never'],
+      code: linesToCode([
+        'expect(x).toBeTrue("with optional args", "???");'
+      ]),
+      output: linesToCode([
+        'expect(x).toBe(true, "with optional args", "???");'
+      ]),
+      errors: [
+        {
+          message: 'Prefer toBe(true) to expect true'
+        }
+      ]
+    }
+  ]
+})


### PR DESCRIPTION
## Description

Added new rules for prefer toBeNull/toBeTrue/toBeFalse. This implements the enhancement #352 
We could discuss whether or not we need rules to prefer toBeTrue/toBeFalse over toBeTruthy/toBeFalsy and what should we call them.

## How has this been tested?

I wrote mocha tests following the same pattern for toBeUndefined

## Types of changes

- [ ] Test change (non-breaking change which adds additional test scenarios)
- [ ] Refactor change (non-breaking change updates coding styles)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have ran `npm run test` and everything passes
- [x] My code follows the code style of this project
- [x] I have updated the documentation where necessary
- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass
