### PR TITLE
Ignore `it` and `describe` nodes with evaluated expressions

### DIFF
--- a/lib/helpers/no-dupes.js
+++ b/lib/helpers/no-dupes.js
@@ -9,6 +9,7 @@ module.exports = function (kind, branchBlocks, checkedBlocks) {
   function noDupes (context) {
     var suites = []
     var branch = []
+    var skippedBranchNodes = []
     var branchMode = context.options[0] === 'branch'
 
     function isBranchNode (node) {
@@ -42,12 +43,14 @@ module.exports = function (kind, branchBlocks, checkedBlocks) {
         var descriptionNode = node.arguments && node.arguments[0]
 
         if (!descriptionNode) {
+          skippedBranchNodes.push(node)
           return
         }
 
         var descriptionLiteral = extractLiteral(descriptionNode)
 
         if (!descriptionLiteral) {
+          skippedBranchNodes.push(node)
           return
         }
 
@@ -76,7 +79,11 @@ module.exports = function (kind, branchBlocks, checkedBlocks) {
       },
       'CallExpression:exit': function (node) {
         if (branchMode && (isBranchNode(node) || isCheckedNode(node))) {
-          branch.pop()
+          if (skippedBranchNodes[skippedBranchNodes.length - 1] === node) {
+            skippedBranchNodes.pop()
+          } else {
+            branch.pop()
+          }
         }
       }
     }

--- a/test/rules/no-spec-dupes.js
+++ b/test/rules/no-spec-dupes.js
@@ -122,6 +122,21 @@ eslintTester.run('no-spec-dupes', rule, {
         '  });',
         '});'
       ], 'same branch until spec')
+    },
+    {
+      options: [
+        'branch'
+      ],
+      code: toCode([
+        'var specName = "evaluated";',
+        'describe("Parent context", function(){',
+        '  it("same spec", function(){});',
+        '  describe("Inner context", function(){',
+        '    it(specName, function(){});',
+        '    it("same spec", function(){});',
+        '  });',
+        '});'
+      ])
     }
   ],
   invalid: [
@@ -222,6 +237,29 @@ eslintTester.run('no-spec-dupes', rule, {
       errors: [
         {
           message: 'Duplicate spec: "parent context same spec"',
+          type: 'CallExpression'
+        }
+      ]
+    },
+    {
+      options: [
+        'branch'
+      ],
+      code: toCode([
+        'var specName = "evaluated";',
+        'describe("Parent context", function(){',
+        '  describe("Inner context", function(){',
+        '    it("same spec", function(){});',
+        '  });',
+        '  describe("Inner context", function(){',
+        '    it(specName, function(){});',
+        '    it("same spec", function(){});',
+        '  });',
+        '});'
+      ], 'same spec in identically named contexts with evaluated spec'),
+      errors: [
+        {
+          message: 'Duplicate spec: "Parent context Inner context same spec"',
           type: 'CallExpression'
         }
       ]

--- a/test/rules/no-suite-dupes.js
+++ b/test/rules/no-suite-dupes.js
@@ -96,6 +96,25 @@ eslintTester.run('no-suite-dupes', rule, {
         '  });',
         '});'
       ])
+    },
+    {
+      options: [
+        'branch'
+      ],
+      code: linesToCode([
+        'var suiteName = "evaluated";',
+        'describe("context", function(){',
+        '  describe("same", function(){',
+        '    // it(...',
+        '  });',
+        '  describe(suiteName, function(){',
+        '    // it(...',
+        '  });',
+        '});',
+        'describe("same", function(){',
+        '  // it(...',
+        '});'
+      ], 'same suite in different levels')
     }
   ],
   invalid: [
@@ -216,6 +235,31 @@ eslintTester.run('no-suite-dupes', rule, {
       errors: [
         {
           message: 'Duplicate suite: "parent context same"',
+          type: 'CallExpression'
+        }
+      ]
+    },
+    {
+      options: [
+        'branch'
+      ],
+      code: linesToCode([
+        'var suiteName = "evaluated";',
+        'describe("context", function(){',
+        '  describe("same", function(){',
+        '    // it(...',
+        '  });',
+        '  describe(suiteName, function(){',
+        '    // it(...',
+        '  });',
+        '  describe("same", function(){',
+        '    // it(...',
+        '  });',
+        '});'
+      ], 'same suite with evaluated suite name in between'),
+      errors: [
+        {
+          message: 'Duplicate suite: "context same"',
           type: 'CallExpression'
         }
       ]


### PR DESCRIPTION
## Description

Corrects rule state in branch mode if a call to `describe` or `it` is encountered with an evaluated expression as first argument. Fixes #164 .

## How has this been tested?

Added mocha tests to `no-suite-dupes` and `no-spec-dupes`, and confirmed that they failed before the change in the `no-dupes` helper.

## Types of changes

- [x] Test change (non-breaking change which adds additional test scenarios)
- [ ] Refactor change (non-breaking change updates coding styles)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have ran `npm run test` and everything passes
- [x] My code follows the code style of this project
- [x] I have updated the documentation where necessary
- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass
