### PR TITLE
[Eslint 9] Add schema declarations

### DIFF
--- a/lib/rules/missing-expect.js
+++ b/lib/rules/missing-expect.js
@@ -7,7 +7,7 @@
 
 var buildName = require('../helpers/buildName')
 
-module.exports = function (context) {
+function create (context) {
   var allowed = context.options.length ? context.options : ['expect()', 'expectAsync()']
 
   var unchecked = []
@@ -41,4 +41,16 @@ module.exports = function (context) {
       })
     }
   }
+}
+
+module.exports = {
+  meta: {
+    schema: {
+      type: 'array',
+      items: {
+        type: 'string'
+      }
+    }
+  },
+  create
 }

--- a/lib/rules/no-expect-in-setup-teardown.js
+++ b/lib/rules/no-expect-in-setup-teardown.js
@@ -7,7 +7,7 @@
 
 var buildName = require('../helpers/buildName')
 
-module.exports = function (context) {
+function create (context) {
   var allowed = context.options.length ? context.options : ['expect()', 'expectAsync()']
   var setupRegexp = /^(before|after)(Each|All)$/
 
@@ -41,4 +41,13 @@ module.exports = function (context) {
       }
     }
   }
+}
+
+var missingExpect = require('./missing-expect')
+
+module.exports = {
+  meta: {
+    schema: missingExpect.meta.schema
+  },
+  create
 }

--- a/lib/rules/no-spec-dupes.js
+++ b/lib/rules/no-spec-dupes.js
@@ -13,4 +13,12 @@ var checkedBlocks = [
   'it'
 ]
 
-module.exports = require('../helpers/no-dupes')('spec', branchBlocks, checkedBlocks)
+var noDupes = require('../helpers/no-dupes')
+var create = noDupes('spec', branchBlocks, checkedBlocks)
+
+module.exports = {
+  meta: {
+    schema: create.schema
+  },
+  create
+}

--- a/lib/rules/no-suite-dupes.js
+++ b/lib/rules/no-suite-dupes.js
@@ -13,4 +13,12 @@ var checkedBlocks = [
   'describe'
 ]
 
-module.exports = require('../helpers/no-dupes')('suite', branchBlocks, checkedBlocks)
+var noDupes = require('../helpers/no-dupes')
+var create = noDupes('suite', branchBlocks, checkedBlocks)
+
+module.exports = {
+  meta: {
+    schema: create.schema
+  },
+  create
+}


### PR DESCRIPTION
## Description

Eslint 9 requires that all rules that accept options implement a `meta.schema` declaration.

There are 5 rules that accept options:
```
missing-expect
no-expect-in-setup-teardown
no-spec-dupes
no-suite-dupes
prefer-toBeUndefined
```
The last one already has a `meta.schema` declaration. This change adds one for the others.

Closes #365

<!-- Describe your changes in detail. -->

## How has this been tested?

Manually, with an installation of eslint 9.

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Test change (non-breaking change which adds additional test scenarios)
- [ ] Refactor change (non-breaking change updates coding styles)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have ran `npm run test` and everything passes
- [x] My code follows the code style of this project
- [ ] I have updated the documentation where necessary
- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests pass
