### PR TITLE
[Eslint 9] Make rules export object with a `create` method

### DIFF
--- a/lib/rules/expect-matcher.js
+++ b/lib/rules/expect-matcher.js
@@ -4,7 +4,7 @@
  * @fileoverview Enforce expect having a corresponding matcher.
  */
 
-module.exports = function (context) {
+function create (context) {
   return {
     CallExpression: function (node) {
       if (node.callee.name === 'expect') {
@@ -19,4 +19,8 @@ module.exports = function (context) {
       }
     }
   }
+}
+
+module.exports = {
+  create
 }

--- a/lib/rules/expect-single-argument.js
+++ b/lib/rules/expect-single-argument.js
@@ -4,7 +4,7 @@
  * @fileoverview Enforce expect having a single argument.
  */
 
-module.exports = function (context) {
+function create (context) {
   return {
     CallExpression: function (node) {
       if (node.callee.name === 'expect') {
@@ -23,4 +23,8 @@ module.exports = function (context) {
       }
     }
   }
+}
+
+module.exports = {
+  create
 }

--- a/lib/rules/named-spy.js
+++ b/lib/rules/named-spy.js
@@ -23,7 +23,7 @@ function findIdentifier (node) {
   }
 }
 
-module.exports = function (context) {
+function create (context) {
   return {
     CallExpression: function (node) {
       if (node.callee.type !== 'MemberExpression') {
@@ -54,4 +54,8 @@ module.exports = function (context) {
       }
     }
   }
+}
+
+module.exports = {
+  create
 }

--- a/lib/rules/no-assign-spyon.js
+++ b/lib/rules/no-assign-spyon.js
@@ -5,7 +5,7 @@
  * @author Remco Haszing
  */
 
-module.exports = function (context) {
+function create (context) {
   return {
     CallExpression: function (node) {
       if (node.callee.name === 'spyOn' && (node.parent.type === 'AssignmentExpression' || node.parent.type === 'VariableDeclarator')) {
@@ -16,4 +16,8 @@ module.exports = function (context) {
       }
     }
   }
+}
+
+module.exports = {
+  create
 }

--- a/lib/rules/no-describe-variables.js
+++ b/lib/rules/no-describe-variables.js
@@ -12,7 +12,7 @@ function report (context, node) {
   })
 }
 
-module.exports = function (context) {
+function create (context) {
   return {
     'CallExpression[callee.name="describe"] > FunctionExpression > BlockStatement > VariableDeclaration': report.bind(this, context),
     'CallExpression[callee.name="xdescribe"] > FunctionExpression > BlockStatement > VariableDeclaration': report.bind(this, context),
@@ -21,4 +21,8 @@ module.exports = function (context) {
     'CallExpression[callee.name="fdescribe"] > ArrowFunctionExpression > BlockStatement > VariableDeclaration': report.bind(this, context),
     'CallExpression[callee.name="xdescribe"] > ArrowFunctionExpression > BlockStatement > VariableDeclaration': report.bind(this, context)
   }
+}
+
+module.exports = {
+  create
 }

--- a/lib/rules/no-disabled-tests.js
+++ b/lib/rules/no-disabled-tests.js
@@ -7,11 +7,15 @@
 
 var prohibit = require('../helpers/prohibit')
 
-module.exports = function (context) {
+function create (context) {
   var prohibiteds = [
     'xdescribe',
     'xit'
   ]
 
   return prohibit(prohibiteds, context)
+}
+
+module.exports = {
+  create
 }

--- a/lib/rules/no-focused-tests.js
+++ b/lib/rules/no-focused-tests.js
@@ -7,7 +7,7 @@
 
 var prohibit = require('../helpers/prohibit')
 
-module.exports = function (context) {
+function create (context) {
   var prohibiteds = [
     'fdescribe',
     'ddescribe',
@@ -16,4 +16,8 @@ module.exports = function (context) {
   ]
 
   return prohibit(prohibiteds, context)
+}
+
+module.exports = {
+  create
 }

--- a/lib/rules/no-global-setup.js
+++ b/lib/rules/no-global-setup.js
@@ -9,7 +9,7 @@ var suiteRegexp = /^(f|d|x)?describe(\..*$)?/
 var setupRegexp = /^(before|after)(Each|All)$/
 var getName = require('../helpers/getName')
 
-module.exports = function (context) {
+function create (context) {
   var suiteDepth = 0
   var hasGlobalSetup = false
   var hasRootSuite = false
@@ -50,4 +50,8 @@ module.exports = function (context) {
       }
     }
   }
+}
+
+module.exports = {
+  create
 }

--- a/lib/rules/no-pending-tests.js
+++ b/lib/rules/no-pending-tests.js
@@ -7,10 +7,14 @@
 
 var prohibit = require('../helpers/prohibit')
 
-module.exports = function (context) {
+function create (context) {
   var prohibiteds = [
     'pending'
   ]
 
   return prohibit(prohibiteds, context)
+}
+
+module.exports = {
+  create
 }

--- a/lib/rules/no-suite-callback-args.js
+++ b/lib/rules/no-suite-callback-args.js
@@ -7,7 +7,7 @@
 
 var suiteRegexp = /^(f|d|x)?describe$/
 
-module.exports = function (context) {
+function create (context) {
   return {
     CallExpression: function (node) {
       if (suiteRegexp.test(node.callee.name) && node.arguments.length > 1) {
@@ -24,4 +24,8 @@ module.exports = function (context) {
       }
     }
   }
+}
+
+module.exports = {
+  create
 }

--- a/lib/rules/no-unsafe-spy.js
+++ b/lib/rules/no-unsafe-spy.js
@@ -17,7 +17,7 @@ function getParentJasmineBlock (ancestors) {
   return false
 }
 
-module.exports = function (context) {
+function create (context) {
   return {
     CallExpression: function (node) {
       if (
@@ -39,4 +39,8 @@ module.exports = function (context) {
       })
     }
   }
+}
+
+module.exports = {
+  create
 }

--- a/lib/rules/prefer-jasmine-matcher.js
+++ b/lib/rules/prefer-jasmine-matcher.js
@@ -9,7 +9,7 @@ var blockRegexp = /^((f|x)?(it|describe))$/
 
 var operators = ['===', '==', '!==', '!=', '>', '<', '>=', '<=']
 
-module.exports = function (context) {
+function create (context) {
   var suiteDepth = 0
   return {
     CallExpression: function (node) {
@@ -31,4 +31,8 @@ module.exports = function (context) {
       }
     }
   }
+}
+
+module.exports = {
+  create
 }

--- a/lib/rules/prefer-toHaveBeenCalledWith.js
+++ b/lib/rules/prefer-toHaveBeenCalledWith.js
@@ -5,7 +5,7 @@
  * @author Diana Suvorova
  */
 
-module.exports = function (context) {
+function create (context) {
   return {
     Identifier: function (node) {
       if (node.name === 'toHaveBeenCalled') {
@@ -21,4 +21,8 @@ module.exports = function (context) {
       }
     }
   }
+}
+
+module.exports = {
+  create
 }

--- a/lib/rules/valid-expect.js
+++ b/lib/rules/valid-expect.js
@@ -6,7 +6,7 @@
  * @author Alexander Afanasyev
  */
 
-module.exports = function (context) {
+function create (context) {
   return {
     CallExpression: function (node) {
       if (node.callee.name === 'expect') {
@@ -44,4 +44,8 @@ module.exports = function (context) {
       }
     }
   }
+}
+
+module.exports = {
+  create
 }


### PR DESCRIPTION
## Description

After upgrading to eslint 9, I get the following error:
```
Oops! Something went wrong! :(

ESLint: 9.4.0

TypeError: Error while loading rule 'jasmine/no-suite-callback-args': Rule must be an object with a `create` method
```

This is because some rules directly export `create` as an anonymous function, which doesn't seem to be tolerated by eslint 9. The solution is to export an object and provide the function under a `create` property.

## How has this been tested?

Manually, with an installation of eslint 9.

## Types of changes

- [ ] Test change (non-breaking change which adds additional test scenarios)
- [ ] Refactor change (non-breaking change updates coding styles)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have ran `npm run test` and everything passes
- [x] My code follows the code style of this project
- [ ] I have updated the documentation where necessary
- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests pass
