### PR TITLE
[Eslint 9] Use new context API

### DIFF
--- a/lib/rules/missing-expect.js
+++ b/lib/rules/missing-expect.js
@@ -23,7 +23,11 @@ function create (context) {
       if (allowed.indexOf(buildName(node)) === -1) {
         return
       }
-      context.getAncestors().some(function (ancestor) {
+      const ancestors = context.sourceCode
+        ? context.sourceCode.getAncestors(node)
+        : context.getAncestors()
+
+      ancestors.some(function (ancestor) {
         var index = unchecked.indexOf(ancestor)
 
         if (index !== -1) {

--- a/lib/rules/new-line-before-expect.js
+++ b/lib/rules/new-line-before-expect.js
@@ -29,7 +29,7 @@ module.exports = {
             return
           }
           lastExpectNode = node
-          var sourceCode = context.getSourceCode()
+          var sourceCode = context.sourceCode || context.getSourceCode()
           let prevToken = sourceCode.getTokenBefore(node)
           if (prevToken.value === 'await' || prevToken.value === 'return') {
             node = prevToken

--- a/lib/rules/no-promise-without-done-fail.js
+++ b/lib/rules/no-promise-without-done-fail.js
@@ -41,7 +41,10 @@ function genReport (node, context) {
     node: node,
     message: 'An "it" that uses an async method should handle failure (use "done.fail")',
     fix: function (fixer) {
-      const lastToken = context.getLastToken(node.parent)
+      const lastToken = context.sourceCode
+        ? context.sourceCode.getLastToken(node.parent)
+        : context.getLastToken(node.parent)
+
       if (!isSemicolon(lastToken)) {
         return fixer.insertTextAfter(node.parent, '.catch(done.fail)')
       } else {

--- a/lib/rules/no-unsafe-spy.js
+++ b/lib/rules/no-unsafe-spy.js
@@ -31,7 +31,11 @@ module.exports = function (context) {
         )
       ) { return }
 
-      if (blocksWhitelistRegexp.test(getParentJasmineBlock(context.getAncestors()))) { return }
+      const ancestors = context.sourceCode
+        ? context.sourceCode.getAncestors(node)
+        : context.getAncestors()
+
+      if (blocksWhitelistRegexp.test(getParentJasmineBlock(ancestors))) { return }
 
       context.report({
         message: 'Spy declared outside of before/after/it block',

--- a/lib/rules/prefer-promise-strategies.js
+++ b/lib/rules/prefer-promise-strategies.js
@@ -46,7 +46,7 @@ module.exports = {
         },
 
         fix (fixer) {
-          const code = context.getSourceCode()
+          const code = context.sourceCode || context.getSourceCode()
           return [
             // Replace Promise constructor call with its arguments
             fixer.remove(promiseCall.callee),

--- a/lib/rules/prefer-toHaveBeenCalledWith.js
+++ b/lib/rules/prefer-toHaveBeenCalledWith.js
@@ -9,7 +9,10 @@ module.exports = function (context) {
   return {
     Identifier: function (node) {
       if (node.name === 'toHaveBeenCalled') {
-        const tokensBefore = context.getTokensBefore(node, 2)
+        const tokensBefore = context.sourceCode
+          ? context.sourceCode.getTokensBefore(node, 2)
+          : context.getTokensBefore(node, 2)
+
         if (tokensBefore[1] && tokensBefore[1].type === 'Punctuator' && tokensBefore[1].value === '.' &&
             tokensBefore[0] && tokensBefore[0].type === 'Identifier' && tokensBefore[0].value === 'not') {
           return


### PR DESCRIPTION
## Description

Eslint 9 has removed a couple of methods from the `context` object. Adapt the code to work with both the new and old eslint runtime.

More info:
https://eslint.org/blog/2023/09/preparing-custom-rules-eslint-v9/

## How has this been tested?

Manually, with an installation of eslint 9.

## Types of changes

- [ ] Test change (non-breaking change which adds additional test scenarios)
- [ ] Refactor change (non-breaking change updates coding styles)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have ran `npm run test` and everything passes
- [x] My code follows the code style of this project
- [ ] I have updated the documentation where necessary
- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests pass
