### PR TITLE
fix(expect-single-argument): Allow no arguments when using nothing

### DIFF
--- a/docs/rules/expect-single-argument.md
+++ b/docs/rules/expect-single-argument.md
@@ -4,7 +4,7 @@ Ensure `expect` is called with a single argument.
 
 ## Rule details
 
-This rule triggers a warning if `expect` is called with more than one argument or without arguments.
+This rule triggers a warning if `expect` is called with more than one argument or without arguments when not followed by a `nothing()`.
 
 ```js
 expect();
@@ -27,4 +27,5 @@ The following patterns are not warnings:
 expect("something").toEqual("something");
 expect([1, 2, 3]).toEqual([1, 2, 3]);
 expect(true).toBeDefined();
+expect().nothing();
 ```

--- a/lib/rules/expect-single-argument.js
+++ b/lib/rules/expect-single-argument.js
@@ -14,7 +14,7 @@ function create (context) {
             message: 'Expect must have a single argument. More than one argument were provided.',
             node
           })
-        } else if (node.arguments.length === 0) {
+        } else if (node.arguments.length === 0 && node.parent.property.name !== 'nothing') {
           context.report({
             message: 'Expect must have a single argument. No arguments were provided.',
             node

--- a/test/rules/expect-single-argument.js
+++ b/test/rules/expect-single-argument.js
@@ -10,7 +10,8 @@ eslintTester.run('expect-single-argument', rule, {
     'expect("something").toEqual("else");',
     'expect(true).toBeDefined();',
     'expect([1, 2, 3]).toEqual([1, 2, 3]);',
-    'expect(undefined).not.toBeDefined();'
+    'expect(undefined).not.toBeDefined();',
+    'expect().nothing();'
   ],
 
   invalid: [


### PR DESCRIPTION
## Description

The expect-single-argument rule gives a warning when you use `expect().nothing();`. This requires you to disable this rule or add a `eslint-disable-next-line` whenever you use `nothing()`. This is mentioned in the following issue: #176 

## How has this been tested?

I added a test case for the `expect().nothing()` case. This case made the tests fail. After changing the rule to allow an `expect()` with no arguments when followed by `nothing()` the tests passed.

## Types of changes

- [ ] Test change (non-breaking change which adds additional test scenarios)
- [ ] Refactor change (non-breaking change updates coding styles)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have ran `npm run test` and everything passes
- [x] My code follows the code style of this project
- [x] I have updated the documentation where necessary
- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass
