### PR TITLE
fix(expect-single-argument): fix error when providing no arguments an…

### DIFF
--- a/lib/rules/expect-single-argument.js
+++ b/lib/rules/expect-single-argument.js
@@ -14,7 +14,7 @@ function create (context) {
             message: 'Expect must have a single argument. More than one argument were provided.',
             node
           })
-        } else if (node.arguments.length === 0 && node.parent.property.name !== 'nothing') {
+        } else if (node.arguments.length === 0 && node.parent?.property?.name !== 'nothing') {
           context.report({
             message: 'Expect must have a single argument. No arguments were provided.',
             node

--- a/lib/rules/expect-single-argument.js
+++ b/lib/rules/expect-single-argument.js
@@ -14,7 +14,7 @@ function create (context) {
             message: 'Expect must have a single argument. More than one argument were provided.',
             node
           })
-        } else if (node.arguments.length === 0 && node.parent?.property?.name !== 'nothing') {
+        } else if (node.arguments.length === 0 && node.parent.property?.name !== 'nothing') {
           context.report({
             message: 'Expect must have a single argument. No arguments were provided.',
             node

--- a/test/rules/expect-single-argument.js
+++ b/test/rules/expect-single-argument.js
@@ -38,6 +38,22 @@ eslintTester.run('expect-single-argument', rule, {
           message: 'Expect must have a single argument. More than one argument were provided.'
         }
       ]
+    },
+    {
+      code: 'expect();',
+      errors: [
+        {
+          message: 'Expect must have a single argument. No arguments were provided.'
+        }
+      ]
+    },
+    {
+      code: 'expect("something", "else");',
+      errors: [
+        {
+          message: 'Expect must have a single argument. More than one argument were provided.'
+        }
+      ]
     }
   ]
 })


### PR DESCRIPTION
## Description

The change to the expect-single-argument rule in #373 crashes when you have an expect without a matcher, as pointed out by KayKadner on that PR. By using optional chaining this rule can now handle expect without a subsequent matcher.

## How has this been tested?

I've added tests for cases where there is no matcher. These indeed threw an error before applying the fix in this PR.

## Types of changes

- [ ] Test change (non-breaking change which adds additional test scenarios)
- [ ] Refactor change (non-breaking change updates coding styles)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [X] I have ran `npm run test` and everything passes
- [X] My code follows the code style of this project
- [X] I have updated the documentation where necessary
- [X] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
- [X] I have added tests to cover my changes
- [X] All new and existing tests pass
