### PR TITLE
fix expect-matcher does not work when withContext is used (#378)

### DIFF
--- a/docs/rules/expect-matcher.md
+++ b/docs/rules/expect-matcher.md
@@ -14,6 +14,8 @@ or when a matcher function was not called:
 
 ```js
 expect(true).toBeDefined
+expect(true).not.toBeDefined
+expect(true).withContext("context")
 ```
 
 
@@ -23,4 +25,5 @@ The following patterns are not warnings:
 expect("something").toEqual("something");
 expect([1, 2, 3]).toEqual([1, 2, 3]);
 expect(true).toBeDefined();
+expect(true).withContext("context").toBeDefined();
 ```

--- a/lib/rules/expect-matcher.js
+++ b/lib/rules/expect-matcher.js
@@ -9,8 +9,15 @@ function create (context) {
     CallExpression: function (node) {
       if (node.callee.name === 'expect') {
         // matcher was not called
-        if (node.parent && node.parent.parent && node.parent.parent.type !== 'CallExpression' &&
-          node.parent.parent.type !== 'MemberExpression') {
+
+        let next = node.parent
+        while (next?.type === 'MemberExpression') {
+          const propName = next.property.name
+          next = next.parent
+          if (propName === 'withContext' && next?.type === 'CallExpression') next = next.parent
+        }
+
+        if (!next || next.type !== 'CallExpression') {
           context.report({
             message: 'Expect must have a corresponding matcher call.',
             node

--- a/test/rules/expect-matcher.js
+++ b/test/rules/expect-matcher.js
@@ -10,7 +10,8 @@ eslintTester.run('expect-matcher', rule, {
     'expect("something").toEqual("else");',
     'expect(true).toBeDefined();',
     'expect([1, 2, 3]).toEqual([1, 2, 3]);',
-    'expect(undefined).not.toBeDefined();'
+    'expect(undefined).not.toBeDefined();',
+    'expect(true).withContext("context").toBeDefined();'
   ],
 
   invalid: [
@@ -32,6 +33,22 @@ eslintTester.run('expect-matcher', rule, {
     },
     {
       code: 'expect(true).toBeDefined;',
+      errors: [
+        {
+          message: 'Expect must have a corresponding matcher call.'
+        }
+      ]
+    },
+    {
+      code: 'expect(true).not.toBeDefined;',
+      errors: [
+        {
+          message: 'Expect must have a corresponding matcher call.'
+        }
+      ]
+    },
+    {
+      code: 'expect(true).withContext("context");',
       errors: [
         {
           message: 'Expect must have a corresponding matcher call.'


### PR DESCRIPTION
## Description

`expect-matcher` rule ignores expressions ending with `withContext` call. See #378 
```js
expect(someCondition).withContext('context string');
```
Changed rule's code skips withContext calls. 
It also skips other MemberExpression nodes to make the rule work in this case:
```js
expect(true).not.toBeDefined;
```

## How has this been tested?

Unittests

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Test change (non-breaking change which adds additional test scenarios)
- [ ] Refactor change (non-breaking change updates coding styles)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have ran `npm run test` and everything passes
- [x] My code follows the code style of this project
- [x] I have updated the documentation where necessary
- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass
